### PR TITLE
Updated GitHub repository name

### DIFF
--- a/src/ArgentPonyWarcraftClient/ArgentPonyWarcraftClient.csproj
+++ b/src/ArgentPonyWarcraftClient/ArgentPonyWarcraftClient.csproj
@@ -11,11 +11,11 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <Title>Argent Pony Warcraft Client</Title>
     <PackageTags>Warcraft World-of-Warcraft WoW Blizzard</PackageTags>
-    <PackageProjectUrl>https://github.com/danjagnow/ArgentPonyWarcraftClient</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/danjagnow/ArgentPonyWarcraftClient</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/blizzard-net/warcraft</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/blizzard-net/warcraft</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageIconUrl>https://raw.githubusercontent.com/danjagnow/ArgentPonyWarcraftClient/master/ArgentPony.png</PackageIconUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/blizzard-net/warcraft/master/ArgentPony.png</PackageIconUrl>
     <RootNamespace>ArgentPonyWarcraftClient</RootNamespace>
     <AssemblyName>ArgentPonyWarcraftClient</AssemblyName>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Updated the GitHub URLs in the csproj file that are used for building the NuGet package.  This was necessary after moving the repository from https://github.com/danjagnow/ArgentPonyWarcraftClient to https://github.com/blizzard-net/warcraft.