### PR TITLE
Updated the handling of versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           command: |
               chmod +x build/semver
               . build/set-version.sh
-              dotnet pack --configuration Release --output ./out/nupkgs -p:Version="${PACKAGE_VERSION}-${PACKAGE_SUFFIX}" --include-symbols --include-source --verbosity minimal
+              dotnet pack --configuration Release --output ./out/nupkgs -p:Version="${PACKAGE_VERSION}" --include-symbols --include-source --verbosity minimal
       - store_artifacts:
           path: out/nupkgs
           destination: nupkgs

--- a/build/set-version.sh
+++ b/build/set-version.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 if [[ -z "${CIRCLE_TAG}" ]]; then
-  export PACKAGE_VERSION=$(build/semver get release $(git describe --tags))
-  export PACKAGE_SUFFIX="ci-${CIRCLE_BUILD_NUM}"
+  # By default, get base version information from the most recent tag and add a "ci" suffix with the build number.
+  export PACKAGE_VERSION_MAJOR=$(build/semver get release $(git describe --tags))
+  export PACKAGE_VERSION="${PACKAGE_VERSION_MAJOR}-ci.${CIRCLE_BUILD_NUM}"
 else
-  export PACKAGE_VERSION=$(build/semver get release ${CIRCLE_TAG})
-  export PACKAGE_SUFFIX=""
+  # For a Git tag that has just been applied, remove the 'v' prefix.
+  export PACKAGE_VERSION=${CIRCLE_TAG//v}
 fi
 
 echo "PACKAGE_VERSION = ${PACKAGE_VERSION}"
-echo "PACKAGE_SUFFIX = ${PACKAGE_SUFFIX}"


### PR DESCRIPTION
Updated the handling of versions.  A single version is now generated by set-version.sh and passed to the dotnet pack operation in the CircleCI config.yml file.