### PR TITLE
Added support for the Mythic Keystone Leaderboard API

### DIFF
--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/WarcraftClientMythicKeystoneLeaderboardApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/WarcraftClientMythicKeystoneLeaderboardApi.cs
@@ -1,0 +1,33 @@
+﻿using System.Threading.Tasks;
+
+namespace ArgentPonyWarcraftClient
+{
+    public partial class WarcraftClient
+    {
+        /// <inheritdoc />
+        public async Task<RequestResult<MythicKeystoneLeaderboardsIndex>> GetMythicKeystoneLeaderboardsIndexAsync(int connectedRealmId, string @namespace)
+        {
+            return await GetMythicKeystoneLeaderboardsIndexAsync(connectedRealmId, @namespace, _region, _locale);
+        }
+
+        /// <inheritdoc />
+        public async Task<RequestResult<MythicKeystoneLeaderboardsIndex>> GetMythicKeystoneLeaderboardsIndexAsync(int connectedRealmId, string @namespace, Region region, Locale locale)
+        {
+            string host = GetHost(region);
+            return await Get<MythicKeystoneLeaderboardsIndex>(region, $"{host}/data/wow/connected-realm/{connectedRealmId}/mythic-leaderboard/index?namespace={@namespace}&locale={locale}");
+        }
+
+        /// <inheritdoc />
+        public async Task<RequestResult<MythicKeystoneLeaderboard>> GetMythicKeystoneLeaderboard(int connectedRealmId, int dungeonId, int period, string @namespace)
+        {
+            return await GetMythicKeystoneLeaderboard(connectedRealmId, dungeonId, period, @namespace, _region, _locale);
+        }
+
+        /// <inheritdoc />
+        public async Task<RequestResult<MythicKeystoneLeaderboard>> GetMythicKeystoneLeaderboard(int connectedRealmId, int dungeonId, int period, string @namespace, Region region, Locale locale)
+        {
+            string host = GetHost(region);
+            return await Get<MythicKeystoneLeaderboard>(region, $"{host}/data/wow/connected-realm/{connectedRealmId}/mythic-leaderboard/{dungeonId}/period/{period}?namespace={@namespace}&locale={locale}");
+        }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Interfaces/GameDataApi/IWarcraftClientGameDataApi.cs
+++ b/src/ArgentPonyWarcraftClient/Interfaces/GameDataApi/IWarcraftClientGameDataApi.cs
@@ -11,6 +11,7 @@
         IWarcraftClientItemApi,
         IWarcraftClientJournalApi,
         IWarcraftClientMountApi,
+        IWarcraftClientMythicKeystoneLeaderboardApi,
         IWarcraftClientPetApi,
         IWarcraftClientPlayableClassApi,
         IWarcraftClientPlayableRaceApi,

--- a/src/ArgentPonyWarcraftClient/Interfaces/GameDataApi/IWarcraftClientMythicKeystoneLeaderboardApi.cs
+++ b/src/ArgentPonyWarcraftClient/Interfaces/GameDataApi/IWarcraftClientMythicKeystoneLeaderboardApi.cs
@@ -1,0 +1,58 @@
+﻿using System.Threading.Tasks;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    ///     A client for the World of Warcraft Mythic Keystone Leaderboard API.
+    /// </summary>
+    public interface IWarcraftClientMythicKeystoneLeaderboardApi
+    {
+        /// <summary>
+        ///     Gets an index of Mythic Keystone Leaderboard dungeon instances for a connected realm.
+        /// </summary>
+        /// <param name="connectedRealmId">The ID of the connected realm.</param>
+        /// <param name="namespace">The namespace to use to locate this document.</param>
+        /// <returns>
+        ///     The index of Mythic Keystone Leaderboard dungeon instances for a connected realm.
+        /// </returns>
+        Task<RequestResult<MythicKeystoneLeaderboardsIndex>> GetMythicKeystoneLeaderboardsIndexAsync(int connectedRealmId, string @namespace);
+
+        /// <summary>
+        ///     Gets an index of Mythic Keystone Leaderboard dungeon instances for a connected realm.
+        /// </summary>
+        /// <param name="connectedRealmId">The ID of the connected realm.</param>
+        /// <param name="namespace">The namespace to use to locate this document.</param>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     The index of Mythic Keystone Leaderboard dungeon instances for a connected realm.
+        /// </returns>
+        Task<RequestResult<MythicKeystoneLeaderboardsIndex>> GetMythicKeystoneLeaderboardsIndexAsync(int connectedRealmId, string @namespace, Region region, Locale locale);
+
+        /// <summary>
+        ///     Gets a Mythic Keystone Leaderboard by period.
+        /// </summary>
+        /// <param name="connectedRealmId">The ID of the connected realm.</param>
+        /// <param name="dungeonId">The ID of the dungeon.</param>
+        /// <param name="period">The unique identifier for the leaderboard period.</param>
+        /// <param name="namespace">The namespace to use to locate this document.</param>
+        /// <returns>
+        ///     A Mythic Keystone Leaderboard for a period.
+        /// </returns>
+        Task<RequestResult<MythicKeystoneLeaderboard>> GetMythicKeystoneLeaderboard(int connectedRealmId, int dungeonId, int period, string @namespace);
+
+        /// <summary>
+        ///     Gets a Mythic Keystone Leaderboard by period.
+        /// </summary>
+        /// <param name="connectedRealmId">The ID of the connected realm.</param>
+        /// <param name="dungeonId">The ID of the dungeon.</param>
+        /// <param name="period">The unique identifier for the leaderboard period.</param>
+        /// <param name="namespace">The namespace to use to locate this document.</param>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     A Mythic Keystone Leaderboard for a period.
+        /// </returns>
+        Task<RequestResult<MythicKeystoneLeaderboard>> GetMythicKeystoneLeaderboard(int connectedRealmId, int dungeonId, int period, string @namespace, Region region, Locale locale);
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/EnumTypeWithoutName.cs
+++ b/src/ArgentPonyWarcraftClient/Models/EnumTypeWithoutName.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// An enumerated type.
+    /// </summary>
+    public class EnumTypeWithoutName
+    {
+        /// <summary>
+        /// Gets the type code for this enumerated value.
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/MythicKeystoneAffix/MythicKeystoneAffixReference.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/MythicKeystoneAffix/MythicKeystoneAffixReference.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// A reference to a mythic keystone affix.
+    /// </summary>
+    public class MythicKeystoneAffixReference
+    {
+        /// <summary>
+        /// Gets the key for the keystone affix.
+        /// </summary>
+        [JsonProperty("key")]
+        public Self Key { get; set; }
+
+        /// <summary>
+        /// Gets the name of the keystone affix.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets the ID of the keystone affix.
+        /// </summary>
+        [JsonProperty("id")]
+        public long Id { get; set; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/MythicKeystoneLeaderboard/LeaderboardKeystoneAffix.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/MythicKeystoneLeaderboard/LeaderboardKeystoneAffix.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// A mythic keystone affix and starting level.
+    /// </summary>
+    public class LeaderboardKeystoneAffix
+    {
+        /// <summary>
+        /// Gets a reference to a mythic keystone affix.
+        /// </summary>
+        [JsonProperty("keystone_affix")]
+        public MythicKeystoneAffixReference KeystoneAffix { get; set; }
+
+        /// <summary>
+        /// Gets the starting level for the mythic keystone affix.
+        /// </summary>
+        [JsonProperty("starting_level")]
+        public long StartingLevel { get; set; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/MythicKeystoneLeaderboard/LeadingGroup.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/MythicKeystoneLeaderboard/LeadingGroup.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// A leading group.
+    /// </summary>
+    public class LeadingGroup
+    {
+        /// <summary>
+        /// Gets the ranking of the group.
+        /// </summary>
+        [JsonProperty("ranking")]
+        public long Ranking { get; set; }
+
+        /// <summary>
+        /// Gets the duration of the run.
+        /// </summary>
+        [JsonProperty("duration")]
+        public long Duration { get; set; }
+
+        /// <summary>
+        /// Gets the timestamp of the completion.
+        /// </summary>
+        [JsonProperty("completed_timestamp")]
+        public DateTime CompletedTimestamp { get; set; }
+
+        /// <summary>
+        /// Gets the keystone level.
+        /// </summary>
+        [JsonProperty("keystone_level")]
+        public long KeystoneLevel { get; set; }
+
+        /// <summary>
+        /// Gets the members of the group.
+        /// </summary>
+        [JsonProperty("members")]
+        public Member[] Members { get; set; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/MythicKeystoneLeaderboard/Member.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/MythicKeystoneLeaderboard/Member.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// A group member.
+    /// </summary>
+    public class Member
+    {
+        /// <summary>
+        /// Gets the profile of the character.
+        /// </summary>
+        [JsonProperty("profile")]
+        public Profile Profile { get; set; }
+
+        /// <summary>
+        /// Gets the character's faction (Alliance or Horde).
+        /// </summary>
+        [JsonProperty("faction")]
+        public EnumTypeWithoutName Faction { get; set; }
+
+        /// <summary>
+        /// Gets the character's specialization.
+        /// </summary>
+        [JsonProperty("specialization")]
+        public PlayableSpecializationReferenceWithoutName Specialization { get; set; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/MythicKeystoneLeaderboard/MythicKeystoneLeaderboard.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/MythicKeystoneLeaderboard/MythicKeystoneLeaderboard.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// A Mythic Keystone Leaderboard for a period.
+    /// </summary>
+    public class MythicKeystoneLeaderboard
+    {
+        /// <summary>
+        /// Gets links for the Mythic Keystone Leaderboard.
+        /// </summary>
+        [JsonProperty("_links")]
+        public Links Links { get; set; }
+
+        /// <summary>
+        /// Gets the map of the instance.
+        /// </summary>
+        [JsonProperty("map")]
+        public Map Map { get; set; }
+
+        /// <summary>
+        /// Gets the unique identifier for the leaderboard period.
+        /// </summary>
+        [JsonProperty("period")]
+        public long Period { get; set; }
+
+        /// <summary>
+        /// Gets the start timestamp for the time period.
+        /// </summary>
+        [JsonProperty("period_start_timestamp")]
+        public DateTime PeriodStartTimestamp { get; set; }
+
+        /// <summary>
+        /// Gets the end timestamp for the time period.
+        /// </summary>
+        [JsonProperty("period_end_timestamp")]
+        public DateTime PeriodEndTimestamp { get; set; }
+
+        /// <summary>
+        /// Gets a reference to the connected realm.
+        /// </summary>
+        [JsonProperty("connected_realm")]
+        public Self ConnectedRealm { get; set; }
+
+        /// <summary>
+        /// Gets the leading troups in this connected realm for this instance and time period.
+        /// </summary>
+        [JsonProperty("leading_groups")]
+        public LeadingGroup[] LeadingGroups { get; set; }
+
+        /// <summary>
+        /// Gets the mythic keystone affixes and starting levels.
+        /// </summary>
+        [JsonProperty("keystone_affixes")]
+        public LeaderboardKeystoneAffix[] KeystoneAffixes { get; set; }
+
+        /// <summary>
+        /// Gets the map challenge mode ID.
+        /// </summary>
+        [JsonProperty("map_challenge_mode_id")]
+        public long MapChallengeModeId { get; set; }
+
+        /// <summary>
+        /// Gets the name of the instance.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/MythicKeystoneLeaderboard/MythicKeystoneLeaderboardReference.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/MythicKeystoneLeaderboard/MythicKeystoneLeaderboardReference.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// A reference to a Mythic Keystone Leaderboard dungeon instance for a connected realm.
+    /// </summary>
+    public class MythicKeystoneLeaderboardReference
+    {
+        /// <summary>
+        /// Gets the key for the Mythic Keystone Leaderboard.
+        /// </summary>
+        [JsonProperty("key")]
+        public Self Key { get; set; }
+
+        /// <summary>
+        /// Gets the name of the Mythic Keystone Leaderboard.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets the ID of the Mythic Keystone Leaderboard.
+        /// </summary>
+        [JsonProperty("id")]
+        public long Id { get; set; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/MythicKeystoneLeaderboard/MythicKeystoneLeaderboardsIndex.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/MythicKeystoneLeaderboard/MythicKeystoneLeaderboardsIndex.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// An index of Mythic Keystone Leaderboard dungeon instances for a connected realm.
+    /// </summary>
+    public class MythicKeystoneLeaderboardsIndex
+    {
+        /// <summary>
+        /// Gets links for the index of Mythic Keystone Leaderboards.
+        /// </summary>
+        [JsonProperty("_links")]
+        public Links Links { get; set; }
+
+        /// <summary>
+        /// Gets references to the Mythic Keystone Leaderboards.
+        /// </summary>
+        [JsonProperty("current_leaderboards")]
+        public MythicKeystoneLeaderboardReference[] CurrentLeaderboards { get; set; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/MythicKeystoneLeaderboard/Profile.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/MythicKeystoneLeaderboard/Profile.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// A character profile.
+    /// </summary>
+    public class Profile
+    {
+        /// <summary>
+        /// Gets the name of the character.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets the ID of the character.
+        /// </summary>
+        [JsonProperty("id")]
+        public long Id { get; set; }
+
+        /// <summary>
+        /// Gets a reference to the character's realm.
+        /// </summary>
+        [JsonProperty("realm")]
+        public RealmReferenceWithoutName Realm { get; set; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/PlayableSpecialization/PlayableSpecializationReferenceWithoutName.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/PlayableSpecialization/PlayableSpecializationReferenceWithoutName.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// A reference to a playable specialization.
+    /// </summary>
+    public class PlayableSpecializationReferenceWithoutName
+    {
+        /// <summary>
+        /// Gets the key for the playable specialization.
+        /// </summary>
+        [JsonProperty("key")]
+        public Self Key { get; set; }
+
+        /// <summary>
+        /// Gets the ID of the playable specialization.
+        /// </summary>
+        [JsonProperty("id")]
+        public long Id { get; set; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Realm/RealmReferenceWithoutName.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Realm/RealmReferenceWithoutName.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// A reference to a realm.
+    /// </summary>
+    public class RealmReferenceWithoutName
+    {
+        /// <summary>
+        /// Gets the key for the realm.
+        /// </summary>
+        [JsonProperty("key")]
+        public Self Key { get; set; }
+
+        /// <summary>
+        /// Gets the ID of the realm.
+        /// </summary>
+        [JsonProperty("id")]
+        public long Id { get; set; }
+
+        /// <summary>
+        /// Gets a slug for the realm.
+        /// </summary>
+        [JsonProperty("slug")]
+        public string Slug { get; set; }
+    }
+}

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/MythicKeystoneLeaderboardApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/MythicKeystoneLeaderboardApiTests.cs
@@ -1,0 +1,30 @@
+﻿using ArgentPonyWarcraftClient.Tests.Properties;
+using Xunit;
+
+namespace ArgentPonyWarcraftClient.Tests
+{
+    public class MythicKeystoneLeaderboardApiTests
+    {
+        [Fact]
+        public async void GetMythicKeystoneLeaderboardsIndexAsync_Gets_MythicKeystoneLeaderboardsIndex()
+        {
+            IWarcraftClientMythicKeystoneLeaderboardApi warcraftClient = ClientFactory.BuildMockClient(
+                requestUri: "https://us.api.blizzard.com/data/wow/connected-realm/11/mythic-leaderboard/index?namespace=dynamic-us&locale=en_US",
+                responseContent: Resources.MythicKeystoneLeaderboardsIndexResponse);
+
+            RequestResult<MythicKeystoneLeaderboardsIndex> result = await warcraftClient.GetMythicKeystoneLeaderboardsIndexAsync(11, "dynamic-us");
+            Assert.NotNull(result.Value);
+        }
+
+        [Fact]
+        public async void GetMythicKeystoneLeaderboard_Gets_MythicKeystoneLeaderboard()
+        {
+            IWarcraftClientMythicKeystoneLeaderboardApi warcraftClient = ClientFactory.BuildMockClient(
+                requestUri: "https://us.api.blizzard.com/data/wow/connected-realm/11/mythic-leaderboard/197/period/641?namespace=dynamic-us&locale=en_US",
+                responseContent: Resources.MythicKeystoneLeaderboardResponse);
+
+            RequestResult<MythicKeystoneLeaderboard> result = await warcraftClient.GetMythicKeystoneLeaderboard(11, 197, 641, "dynamic-us");
+            Assert.NotNull(result.Value);
+        }
+    }
+}

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
@@ -1023,6 +1023,58 @@ namespace ArgentPonyWarcraftClient.Tests.Properties {
         ///   Looks up a localized string similar to {
         ///  &quot;_links&quot;: {
         ///    &quot;self&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/connected-realm/11/mythic-leaderboard/197/period/641?namespace=dynamic-us&quot;
+        ///    }
+        ///  },
+        ///  &quot;map&quot;: {
+        ///    &quot;name&quot;: &quot;Eye of Azshara&quot;,
+        ///    &quot;id&quot;: 1456
+        ///  },
+        ///  &quot;period&quot;: 641,
+        ///  &quot;period_start_timestamp&quot;: 1523372400000,
+        ///  &quot;period_end_timestamp&quot;: 1523977199000,
+        ///  &quot;connected_realm&quot;: {
+        ///    &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/connected-realm/11?namespace=dynamic-us&quot;
+        ///  },
+        ///  &quot;leading_groups&quot;: [
+        ///    {
+        ///      &quot;ranking&quot;:  [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string MythicKeystoneLeaderboardResponse {
+            get {
+                return ResourceManager.GetString("MythicKeystoneLeaderboardResponse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {
+        ///  &quot;_links&quot;: {
+        ///    &quot;self&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/connected-realm/11/mythic-leaderboard/?namespace=dynamic-us&quot;
+        ///    }
+        ///  },
+        ///  &quot;current_leaderboards&quot;: [
+        ///    {
+        ///      &quot;key&quot;: {
+        ///        &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/connected-realm/11/mythic-leaderboard/244/period/755?namespace=dynamic-us&quot;
+        ///      },
+        ///      &quot;name&quot;: &quot;Atal&apos;Dazar&quot;,
+        ///      &quot;id&quot;: 244
+        ///    },
+        ///    {
+        ///      &quot;key&quot;: {
+        ///        &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/connected-realm/11/mythic-lea [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string MythicKeystoneLeaderboardsIndexResponse {
+            get {
+                return ResourceManager.GetString("MythicKeystoneLeaderboardsIndexResponse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {
+        ///  &quot;_links&quot;: {
+        ///    &quot;self&quot;: {
         ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/pet-ability/?namespace=static-8.3.0_32861-us&quot;
         ///    }
         ///  },

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
@@ -58405,4 +58405,508 @@
   "id": 1
 }</value>
   </data>
+  <data name="MythicKeystoneLeaderboardsIndexResponse" xml:space="preserve">
+    <value>{
+  "_links": {
+    "self": {
+      "href": "https://us.api.blizzard.com/data/wow/connected-realm/11/mythic-leaderboard/?namespace=dynamic-us"
+    }
+  },
+  "current_leaderboards": [
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/connected-realm/11/mythic-leaderboard/244/period/755?namespace=dynamic-us"
+      },
+      "name": "Atal'Dazar",
+      "id": 244
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/connected-realm/11/mythic-leaderboard/245/period/755?namespace=dynamic-us"
+      },
+      "name": "Freehold",
+      "id": 245
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/connected-realm/11/mythic-leaderboard/246/period/755?namespace=dynamic-us"
+      },
+      "name": "Tol Dagor",
+      "id": 246
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/connected-realm/11/mythic-leaderboard/247/period/755?namespace=dynamic-us"
+      },
+      "name": "The MOTHERLODE!!",
+      "id": 247
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/connected-realm/11/mythic-leaderboard/248/period/755?namespace=dynamic-us"
+      },
+      "name": "Waycrest Manor",
+      "id": 248
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/connected-realm/11/mythic-leaderboard/249/period/755?namespace=dynamic-us"
+      },
+      "name": "Kings' Rest",
+      "id": 249
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/connected-realm/11/mythic-leaderboard/250/period/755?namespace=dynamic-us"
+      },
+      "name": "Temple of Sethraliss",
+      "id": 250
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/connected-realm/11/mythic-leaderboard/251/period/755?namespace=dynamic-us"
+      },
+      "name": "The Underrot",
+      "id": 251
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/connected-realm/11/mythic-leaderboard/252/period/755?namespace=dynamic-us"
+      },
+      "name": "Shrine of the Storm",
+      "id": 252
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/connected-realm/11/mythic-leaderboard/353/period/755?namespace=dynamic-us"
+      },
+      "name": "Siege of Boralus",
+      "id": 353
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/connected-realm/11/mythic-leaderboard/369/period/755?namespace=dynamic-us"
+      },
+      "name": "Operation: Mechagon - Junkyard",
+      "id": 369
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/connected-realm/11/mythic-leaderboard/370/period/755?namespace=dynamic-us"
+      },
+      "name": "Operation: Mechagon - Workshop",
+      "id": 370
+    }
+  ]
+}</value>
+  </data>
+  <data name="MythicKeystoneLeaderboardResponse" xml:space="preserve">
+    <value>{
+  "_links": {
+    "self": {
+      "href": "https://us.api.blizzard.com/data/wow/connected-realm/11/mythic-leaderboard/197/period/641?namespace=dynamic-us"
+    }
+  },
+  "map": {
+    "name": "Eye of Azshara",
+    "id": 1456
+  },
+  "period": 641,
+  "period_start_timestamp": 1523372400000,
+  "period_end_timestamp": 1523977199000,
+  "connected_realm": {
+    "href": "https://us.api.blizzard.com/data/wow/connected-realm/11?namespace=dynamic-us"
+  },
+  "leading_groups": [
+    {
+      "ranking": 1,
+      "duration": 4701656,
+      "completed_timestamp": 1523646535000,
+      "keystone_level": 25,
+      "members": [
+        {
+          "profile": {
+            "name": "Volladin",
+            "id": 186986280,
+            "realm": {
+              "key": {
+                "href": "https://us.api.blizzard.com/data/wow/realm/61?namespace=dynamic-us"
+              },
+              "id": 61,
+              "slug": "zuljin"
+            }
+          },
+          "faction": {
+            "type": "HORDE"
+          },
+          "specialization": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/playable-specialization/65?namespace=static-7.3.5_25875-us"
+            },
+            "id": 65
+          }
+        },
+        {
+          "profile": {
+            "name": "Elishaa",
+            "id": 187880653,
+            "realm": {
+              "key": {
+                "href": "https://us.api.blizzard.com/data/wow/realm/73?namespace=dynamic-us"
+              },
+              "id": 73,
+              "slug": "bleeding-hollow"
+            }
+          },
+          "faction": {
+            "type": "HORDE"
+          },
+          "specialization": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/playable-specialization/581?namespace=static-7.3.5_25875-us"
+            },
+            "id": 581
+          }
+        },
+        {
+          "profile": {
+            "name": "Jackson",
+            "id": 142410055,
+            "realm": {
+              "key": {
+                "href": "https://us.api.blizzard.com/data/wow/realm/73?namespace=dynamic-us"
+              },
+              "id": 73,
+              "slug": "bleeding-hollow"
+            }
+          },
+          "faction": {
+            "type": "HORDE"
+          },
+          "specialization": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/playable-specialization/259?namespace=static-7.3.5_25875-us"
+            },
+            "id": 259
+          }
+        },
+        {
+          "profile": {
+            "name": "Pearcake",
+            "id": 179791270,
+            "realm": {
+              "key": {
+                "href": "https://us.api.blizzard.com/data/wow/realm/11?namespace=dynamic-us"
+              },
+              "id": 11,
+              "slug": "tichondrius"
+            }
+          },
+          "faction": {
+            "type": "HORDE"
+          },
+          "specialization": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/playable-specialization/265?namespace=static-7.3.5_25875-us"
+            },
+            "id": 265
+          }
+        },
+        {
+          "profile": {
+            "name": "Snöwy",
+            "id": 132319941,
+            "realm": {
+              "key": {
+                "href": "https://us.api.blizzard.com/data/wow/realm/57?namespace=dynamic-us"
+              },
+              "id": 57,
+              "slug": "illidan"
+            }
+          },
+          "faction": {
+            "type": "HORDE"
+          },
+          "specialization": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/playable-specialization/63?namespace=static-7.3.5_25875-us"
+            },
+            "id": 63
+          }
+        }
+      ]
+    },
+    {
+      "ranking": 2,
+      "duration": 2810578,
+      "completed_timestamp": 1523583162000,
+      "keystone_level": 23,
+      "members": [
+        {
+          "profile": {
+            "name": "Noru",
+            "id": 180317150,
+            "realm": {
+              "key": {
+                "href": "https://us.api.blizzard.com/data/wow/realm/10?namespace=dynamic-us"
+              },
+              "id": 10,
+              "slug": "blackrock"
+            }
+          },
+          "faction": {
+            "type": "HORDE"
+          },
+          "specialization": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/playable-specialization/103?namespace=static-7.3.5_25875-us"
+            },
+            "id": 103
+          }
+        },
+        {
+          "profile": {
+            "name": "Spicyramyun",
+            "id": 179491557,
+            "realm": {
+              "key": {
+                "href": "https://us.api.blizzard.com/data/wow/realm/11?namespace=dynamic-us"
+              },
+              "id": 11,
+              "slug": "tichondrius"
+            }
+          },
+          "faction": {
+            "type": "HORDE"
+          },
+          "specialization": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/playable-specialization/72?namespace=static-7.3.5_25875-us"
+            },
+            "id": 72
+          }
+        },
+        {
+          "profile": {
+            "name": "Viirx",
+            "id": 166923740,
+            "realm": {
+              "key": {
+                "href": "https://us.api.blizzard.com/data/wow/realm/1263?namespace=dynamic-us"
+              },
+              "id": 1263,
+              "slug": "thrall"
+            }
+          },
+          "faction": {
+            "type": "HORDE"
+          },
+          "specialization": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/playable-specialization/250?namespace=static-7.3.5_25875-us"
+            },
+            "id": 250
+          }
+        },
+        {
+          "profile": {
+            "name": "Tr",
+            "id": 125313974,
+            "realm": {
+              "key": {
+                "href": "https://us.api.blizzard.com/data/wow/realm/10?namespace=dynamic-us"
+              },
+              "id": 10,
+              "slug": "blackrock"
+            }
+          },
+          "faction": {
+            "type": "HORDE"
+          },
+          "specialization": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/playable-specialization/105?namespace=static-7.3.5_25875-us"
+            },
+            "id": 105
+          }
+        },
+        {
+          "profile": {
+            "name": "Clofnihbr",
+            "id": 175694437,
+            "realm": {
+              "key": {
+                "href": "https://us.api.blizzard.com/data/wow/realm/1263?namespace=dynamic-us"
+              },
+              "id": 1263,
+              "slug": "thrall"
+            }
+          },
+          "faction": {
+            "type": "HORDE"
+          },
+          "specialization": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/playable-specialization/265?namespace=static-7.3.5_25875-us"
+            },
+            "id": 265
+          }
+        }
+      ]
+    },
+    {
+      "ranking": 500,
+      "duration": 1816054,
+      "completed_timestamp": 1523759505000,
+      "keystone_level": 15,
+      "members": [
+        {
+          "profile": {
+            "name": "Balanceteam",
+            "id": 179161603,
+            "realm": {
+              "key": {
+                "href": "https://us.api.blizzard.com/data/wow/realm/57?namespace=dynamic-us"
+              },
+              "id": 57,
+              "slug": "illidan"
+            }
+          },
+          "faction": {
+            "type": "HORDE"
+          },
+          "specialization": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/playable-specialization/269?namespace=static-7.3.5_25875-us"
+            },
+            "id": 269
+          }
+        },
+        {
+          "profile": {
+            "name": "Bapcha",
+            "id": 133107582,
+            "realm": {
+              "key": {
+                "href": "https://us.api.blizzard.com/data/wow/realm/11?namespace=dynamic-us"
+              },
+              "id": 11,
+              "slug": "tichondrius"
+            }
+          },
+          "faction": {
+            "type": "HORDE"
+          },
+          "specialization": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/playable-specialization/65?namespace=static-7.3.5_25875-us"
+            },
+            "id": 65
+          }
+        },
+        {
+          "profile": {
+            "name": "Coolshiine",
+            "id": 177333613,
+            "realm": {
+              "key": {
+                "href": "https://us.api.blizzard.com/data/wow/realm/3723?namespace=dynamic-us"
+              },
+              "id": 3723,
+              "slug": "barthilas"
+            }
+          },
+          "faction": {
+            "type": "HORDE"
+          },
+          "specialization": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/playable-specialization/63?namespace=static-7.3.5_25875-us"
+            },
+            "id": 63
+          }
+        },
+        {
+          "profile": {
+            "name": "Wowprogress",
+            "id": 58815968,
+            "realm": {
+              "key": {
+                "href": "https://us.api.blizzard.com/data/wow/realm/3726?namespace=dynamic-us"
+              },
+              "id": 3726,
+              "slug": "khazgoroth"
+            }
+          },
+          "faction": {
+            "type": "HORDE"
+          },
+          "specialization": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/playable-specialization/250?namespace=static-7.3.5_25875-us"
+            },
+            "id": 250
+          }
+        },
+        {
+          "profile": {
+            "name": "Agonized",
+            "id": 173711224,
+            "realm": {
+              "key": {
+                "href": "https://us.api.blizzard.com/data/wow/realm/3723?namespace=dynamic-us"
+              },
+              "id": 3723,
+              "slug": "barthilas"
+            }
+          },
+          "faction": {
+            "type": "HORDE"
+          },
+          "specialization": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/playable-specialization/265?namespace=static-7.3.5_25875-us"
+            },
+            "id": 265
+          }
+        }
+      ]
+    }
+  ],
+  "keystone_affixes": [
+    {
+      "keystone_affix": {
+        "key": {
+          "href": "https://us.api.blizzard.com/data/wow/keystone-affix/6?namespace=static-7.3.5_25875-us"
+        },
+        "name": "Raging",
+        "id": 6
+      },
+      "starting_level": 4
+    },
+    {
+      "keystone_affix": {
+        "key": {
+          "href": "https://us.api.blizzard.com/data/wow/keystone-affix/4?namespace=static-7.3.5_25875-us"
+        },
+        "name": "Necrotic",
+        "id": 4
+      },
+      "starting_level": 7
+    },
+    {
+      "keystone_affix": {
+        "key": {
+          "href": "https://us.api.blizzard.com/data/wow/keystone-affix/9?namespace=static-7.3.5_25875-us"
+        },
+        "name": "Tyrannical",
+        "id": 9
+      },
+      "starting_level": 10
+    }
+  ],
+  "map_challenge_mode_id": 197,
+  "name": "Eye of Azshara"
+}</value>
+  </data>
 </root>


### PR DESCRIPTION
Added support for the Mythic Keystone Leaderboard API.  Added an IWarcraftClientMythicKeystoneLeaderboardApi interface to describe the capabilities of the API.  The IWarcraftClient interface implements this interface via the IWarcraftClientGameDataApi interface.  Added some ugly "WithoutName" class variants like EnumTypeWithoutName.