### PR TITLE
Added support for the Mythic Raid Leaderboard API

### DIFF
--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/WarcraftClientMythicRaidLeaderboardApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/WarcraftClientMythicRaidLeaderboardApi.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading.Tasks;
+
+namespace ArgentPonyWarcraftClient
+{
+    public partial class WarcraftClient
+    {
+        /// <inheritdoc />
+        public async Task<RequestResult<MythicRaidLeaderboard>> GetMythicRaidLeaderboardAsync(string raid, string faction, string @namespace)
+        {
+            return await GetMythicRaidLeaderboardAsync(raid, faction, @namespace, _region, _locale);
+        }
+
+        /// <inheritdoc />
+        public async Task<RequestResult<MythicRaidLeaderboard>> GetMythicRaidLeaderboardAsync(string raid, string faction, string @namespace, Region region, Locale locale)
+        {
+            string host = GetHost(region);
+            return await Get<MythicRaidLeaderboard>(region, $"{host}/data/wow/leaderboard/hall-of-fame/{raid}/{faction}?namespace={@namespace}&locale={locale}");
+        }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Interfaces/GameDataApi/IWarcraftClientGameDataApi.cs
+++ b/src/ArgentPonyWarcraftClient/Interfaces/GameDataApi/IWarcraftClientGameDataApi.cs
@@ -12,6 +12,7 @@
         IWarcraftClientJournalApi,
         IWarcraftClientMountApi,
         IWarcraftClientMythicKeystoneLeaderboardApi,
+        IWarcraftClientMythicRaidLeaderboardApi,
         IWarcraftClientPetApi,
         IWarcraftClientPlayableClassApi,
         IWarcraftClientPlayableRaceApi,

--- a/src/ArgentPonyWarcraftClient/Interfaces/GameDataApi/IWarcraftClientMythicRaidLeaderboardApi.cs
+++ b/src/ArgentPonyWarcraftClient/Interfaces/GameDataApi/IWarcraftClientMythicRaidLeaderboardApi.cs
@@ -1,0 +1,34 @@
+﻿using System.Threading.Tasks;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    ///     A client for the World of Warcraft Mythic Raid Leaderboard API.
+    /// </summary>
+    public interface IWarcraftClientMythicRaidLeaderboardApi
+    {
+        /// <summary>
+        ///     Gets the leaderboard for a given raid and faction.
+        /// </summary>
+        /// <param name="raid">The raid for a leaderboard.</param>
+        /// <param name="faction">The player faction ("alliance" or "horde").</param>
+        /// <param name="namespace">The namespace to use to locate this document.</param>
+        /// <returns>
+        ///     The leaderboard for a given raid and faction.
+        /// </returns>
+        Task<RequestResult<MythicRaidLeaderboard>> GetMythicRaidLeaderboardAsync(string raid, string faction, string @namespace);
+
+        /// <summary>
+        ///     Gets the leaderboard for a given raid and faction.
+        /// </summary>
+        /// <param name="raid">The raid for a leaderboard.</param>
+        /// <param name="faction">The player faction ("alliance" or "horde").</param>
+        /// <param name="namespace">The namespace to use to locate this document.</param>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     The leaderboard for a given raid and faction.
+        /// </returns>
+        Task<RequestResult<MythicRaidLeaderboard>> GetMythicRaidLeaderboardAsync(string raid, string faction, string @namespace, Region region, Locale locale);
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/MythicRaidLeaderboard/MythicRaidLeaderboard.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/MythicRaidLeaderboard/MythicRaidLeaderboard.cs
@@ -1,0 +1,40 @@
+﻿using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// The Mythic Raid leaderboard for a given raid and faction.
+    /// </summary>
+    public class MythicRaidLeaderboard
+    {
+        /// <summary>
+        /// Gets links for the Mythic Raid leaderboard.
+        /// </summary>
+        [JsonProperty("_links")]
+        public Links Links { get; set; }
+
+        /// <summary>
+        /// Gets the slug for the raid and faction.
+        /// </summary>
+        [JsonProperty("slug")]
+        public string Slug { get; set; }
+
+        /// <summary>
+        /// Gets the criteria type.
+        /// </summary>
+        [JsonProperty("criteria_type")]
+        public string CriteriaType { get; set; }
+
+        /// <summary>
+        /// Gets a reference to the zone for the raid.
+        /// </summary>
+        [JsonProperty("zone")]
+        public ZoneReference Zone { get; set; }
+
+        /// <summary>
+        /// Gets the entries for the Mythic Raid leaderboard.
+        /// </summary>
+        [JsonProperty("entries")]
+        public MythicRaidLeaderboardEntry[] Entries { get; set; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/MythicRaidLeaderboard/MythicRaidLeaderboardEntry.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/MythicRaidLeaderboard/MythicRaidLeaderboardEntry.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// An entry in a Mythic Raid leaderboard.
+    /// </summary>
+    public class MythicRaidLeaderboardEntry
+    {
+        /// <summary>
+        /// Gets a reference to the guild.
+        /// </summary>
+        [JsonProperty("guild")]
+        public GuildReferenceWithoutKeyAndFaction Guild { get; set; }
+
+        /// <summary>
+        /// Gets the faction.
+        /// </summary>
+        [JsonProperty("faction")]
+        public EnumTypeWithoutName Faction { get; set; }
+
+        /// <summary>
+        /// Gets the timestamp.
+        /// </summary>
+        [JsonProperty("timestamp")]
+        public DateTime Timestamp { get; set; }
+
+        /// <summary>
+        /// Gets the region.
+        /// </summary>
+        [JsonProperty("region")]
+        public string Region { get; set; }
+
+        /// <summary>
+        /// Gets the rank.
+        /// </summary>
+        [JsonProperty("rank")]
+        public long Rank { get; set; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/MythicRaidLeaderboard/ZoneReference.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/MythicRaidLeaderboard/ZoneReference.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// A reference to a zone.
+    /// </summary>
+    public class ZoneReference
+    {
+        /// <summary>
+        /// Gets the key for the zone.
+        /// </summary>
+        [JsonProperty("key")]
+        public Self Key { get; set; }
+
+        /// <summary>
+        /// Gets the name of the zone.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Realm/RealmReferenceWithoutKey.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Realm/RealmReferenceWithoutKey.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// A reference to a realm.
+    /// </summary>
+    public class RealmReferenceWithoutKey
+    {
+        /// <summary>
+        /// Gets the name of the realm.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets the ID of the realm.
+        /// </summary>
+        [JsonProperty("id")]
+        public long Id { get; set; }
+
+        /// <summary>
+        /// Gets a slug for the realm.
+        /// </summary>
+        [JsonProperty("slug")]
+        public string Slug { get; set; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/ProfileApi/Guild/GuildReferenceWithoutKeyAndFaction.cs
+++ b/src/ArgentPonyWarcraftClient/Models/ProfileApi/Guild/GuildReferenceWithoutKeyAndFaction.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// A reference to a guild.
+    /// </summary>
+    public class GuildReferenceWithoutKeyAndFaction
+    {
+        /// <summary>
+        /// Gets the name of the guild.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets the ID of the guild.
+        /// </summary>
+        [JsonProperty("id")]
+        public long Id { get; set; }
+
+        /// <summary>
+        /// Gets a reference to the realm to which the guild belongs.
+        /// </summary>
+        [JsonProperty("realm")]
+        public RealmReferenceWithoutKey Realm { get; set; }
+    }
+}

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/MythicRaidLeaderboardApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/MythicRaidLeaderboardApiTests.cs
@@ -1,0 +1,19 @@
+﻿using ArgentPonyWarcraftClient.Tests.Properties;
+using Xunit;
+
+namespace ArgentPonyWarcraftClient.Tests
+{
+    public class MythicRaidLeaderboardApiTests
+    {
+        [Fact]
+        public async void GetMythicKeystoneLeaderboardsIndexAsync_Gets_MythicKeystoneLeaderboardsIndex()
+        {
+            IWarcraftClientMythicRaidLeaderboardApi warcraftClient = ClientFactory.BuildMockClient(
+                requestUri: "https://us.api.blizzard.com/data/wow/leaderboard/hall-of-fame/uldir/alliance?namespace=dynamic-us&locale=en_US",
+                responseContent: Resources.MythicRaidLeaderboardResponse);
+
+            RequestResult<MythicRaidLeaderboard> result = await warcraftClient.GetMythicRaidLeaderboardAsync("uldir", "alliance", "dynamic-us");
+            Assert.NotNull(result.Value);
+        }
+    }
+}

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
@@ -1130,6 +1130,36 @@ namespace ArgentPonyWarcraftClient.Tests.Properties {
         ///   Looks up a localized string similar to {
         ///  &quot;_links&quot;: {
         ///    &quot;self&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/leaderboard/hall-of-fame/uldir/alliance?namespace=dynamic-us&quot;
+        ///    }
+        ///  },
+        ///  &quot;slug&quot;: &quot;uldir-alliance&quot;,
+        ///  &quot;criteria_type&quot;: &quot;hall-of-fame&quot;,
+        ///  &quot;zone&quot;: {
+        ///    &quot;key&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/zone/9389?namespace=static-us&quot;
+        ///    },
+        ///    &quot;name&quot;: &quot;Uldir&quot;
+        ///  },
+        ///  &quot;entries&quot;: [
+        ///    {
+        ///      &quot;guild&quot;: {
+        ///        &quot;name&quot;: &quot;阿尔法&quot;,
+        ///        &quot;id&quot;: 31307591,
+        ///        &quot;realm&quot;: {
+        ///          &quot;name&quot;: &quot;Rhonin&quot;,
+        ///  [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string MythicRaidLeaderboardResponse {
+            get {
+                return ResourceManager.GetString("MythicRaidLeaderboardResponse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {
+        ///  &quot;_links&quot;: {
+        ///    &quot;self&quot;: {
         ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/pet-ability/?namespace=static-8.3.0_32861-us&quot;
         ///    }
         ///  },

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
@@ -61036,4 +61036,91 @@
   }
 }</value>
   </data>
+  <data name="MythicRaidLeaderboardResponse" xml:space="preserve">
+    <value>{
+  "_links": {
+    "self": {
+      "href": "https://us.api.blizzard.com/data/wow/leaderboard/hall-of-fame/uldir/alliance?namespace=dynamic-us"
+    }
+  },
+  "slug": "uldir-alliance",
+  "criteria_type": "hall-of-fame",
+  "zone": {
+    "key": {
+      "href": "https://us.api.blizzard.com/data/wow/zone/9389?namespace=static-us"
+    },
+    "name": "Uldir"
+  },
+  "entries": [
+    {
+      "guild": {
+        "name": "阿尔法",
+        "id": 31307591,
+        "realm": {
+          "name": "Rhonin",
+          "id": 729,
+          "slug": "rhonin"
+        }
+      },
+      "faction": {
+        "type": "ALLIANCE"
+      },
+      "timestamp": 1537733917000,
+      "region": "cn",
+      "rank": 1
+    },
+    {
+      "guild": {
+        "name": "Honestly",
+        "id": 41321785,
+        "realm": {
+          "name": "Frostmourne",
+          "id": 3725,
+          "slug": "frostmourne"
+        }
+      },
+      "faction": {
+        "type": "ALLIANCE"
+      },
+      "timestamp": 1538129132000,
+      "region": "us",
+      "rank": 2
+    },
+    {
+      "guild": {
+        "name": "P G",
+        "id": 49912595,
+        "realm": {
+          "name": "Ravencrest",
+          "id": 554,
+          "slug": "ravencrest"
+        }
+      },
+      "faction": {
+        "type": "ALLIANCE"
+      },
+      "timestamp": 1538159395000,
+      "region": "eu",
+      "rank": 3
+    },
+    {
+      "guild": {
+        "name": "Phoenix",
+        "id": 40075794,
+        "realm": {
+          "name": "Silvermoon",
+          "id": 549,
+          "slug": "silvermoon"
+        }
+      },
+      "faction": {
+        "type": "ALLIANCE"
+      },
+      "timestamp": 1541454206000,
+      "region": "eu",
+      "rank": 100
+    }
+  ]
+}</value>
+  </data>
 </root>


### PR DESCRIPTION
Added support for the Mythic Raid Leaderboard API.  Added an IWarcraftClientMythicRaidLeaderboardApi interface to describe the capabilities of the API.  The IWarcraftClient interface implements this interface via the IWarcraftClientGameDataApi interface.