### PR TITLE
Added support for the PvP Tier API

### DIFF
--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/WarcraftClientPvpTierApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/WarcraftClientPvpTierApi.cs
@@ -1,0 +1,46 @@
+﻿using System.Threading.Tasks;
+
+namespace ArgentPonyWarcraftClient
+{
+    public partial class WarcraftClient
+    {
+        /// <inheritdoc />
+        public async Task<RequestResult<PvpTiersIndex>> GetPvpTiersIndexAsync(string @namespace)
+        {
+            return await GetPvpTiersIndexAsync(@namespace, _region, _locale);
+        }
+
+        /// <inheritdoc />
+        public async Task<RequestResult<PvpTiersIndex>> GetPvpTiersIndexAsync(string @namespace, Region region, Locale locale)
+        {
+            string host = GetHost(region);
+            return await Get<PvpTiersIndex>(region, $"{host}/data/wow/pvp-tier/index?namespace={@namespace}&locale={locale}");
+        }
+
+        /// <inheritdoc />
+        public async Task<RequestResult<PvpTier>> GetPvpTierAsync(int pvpTierId, string @namespace)
+        {
+            return await GetPvpTierAsync(pvpTierId, @namespace, _region, _locale);
+        }
+
+        /// <inheritdoc />
+        public async Task<RequestResult<PvpTier>> GetPvpTierAsync(int pvpTierId, string @namespace, Region region, Locale locale)
+        {
+            string host = GetHost(region);
+            return await Get<PvpTier>(region, $"{host}/data/wow/pvp-tier/{pvpTierId}?namespace={@namespace}&locale={locale}");
+        }
+
+        /// <inheritdoc />
+        public async Task<RequestResult<PvpTierMedia>> GetPvpTierMediaAsync(int pvpTierId, string @namespace)
+        {
+            return await GetPvpTierMediaAsync(pvpTierId, @namespace, _region, _locale);
+        }
+
+        /// <inheritdoc />
+        public async Task<RequestResult<PvpTierMedia>> GetPvpTierMediaAsync(int pvpTierId, string @namespace, Region region, Locale locale)
+        {
+            string host = GetHost(region);
+            return await Get<PvpTierMedia>(region, $"{host}/data/wow/media/pvp-tier/{pvpTierId}?namespace={@namespace}&locale={locale}");
+        }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Interfaces/GameDataApi/IWarcraftClientGameDataApi.cs
+++ b/src/ArgentPonyWarcraftClient/Interfaces/GameDataApi/IWarcraftClientGameDataApi.cs
@@ -20,6 +20,7 @@
         IWarcraftClientPlayableRaceApi,
         IWarcraftClientProfessionApi,
         IWarcraftClientPvpSeasonApi,
+        IWarcraftClientPvpTierApi,
         IWarcraftClientQuestApi,
         IWarcraftClientRealmApi,
         IWarcraftClientSpellApi,

--- a/src/ArgentPonyWarcraftClient/Interfaces/GameDataApi/IWarcraftClientPvpTierApi.cs
+++ b/src/ArgentPonyWarcraftClient/Interfaces/GameDataApi/IWarcraftClientPvpTierApi.cs
@@ -1,0 +1,74 @@
+﻿using System.Threading.Tasks;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    ///     A client for the World of Warcraft PvP Tier API.
+    /// </summary>
+    public interface IWarcraftClientPvpTierApi
+    {
+        /// <summary>
+        ///     Gets an index of PvP tiers.
+        /// </summary>
+        /// <param name="namespace">The namespace to use to locate this document.</param>
+        /// <returns>
+        ///     The PvP tier index.
+        /// </returns>
+        Task<RequestResult<PvpTiersIndex>> GetPvpTiersIndexAsync(string @namespace);
+
+        /// <summary>
+        ///     Gets an index of PvP tiers.
+        /// </summary>
+        /// <param name="namespace">The namespace to use to locate this document.</param>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     The PvP tier index.
+        /// </returns>
+        Task<RequestResult<PvpTiersIndex>> GetPvpTiersIndexAsync(string @namespace, Region region, Locale locale);
+
+        /// <summary>
+        ///     Get the specified PvP tier.
+        /// </summary>
+        /// <param name="pvpTierId">The PvP tier ID.</param>
+        /// <param name="namespace">The namespace to use to locate this document.</param>
+        /// <returns>
+        ///     The specified PvP tier.
+        /// </returns>
+        Task<RequestResult<PvpTier>> GetPvpTierAsync(int pvpTierId, string @namespace);
+
+        /// <summary>
+        ///     Get the specified PvP tier.
+        /// </summary>
+        /// <param name="pvpTierId">The PvP tier ID.</param>
+        /// <param name="namespace">The namespace to use to locate this document.</param>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     The specified PvP tier.
+        /// </returns>
+        Task<RequestResult<PvpTier>> GetPvpTierAsync(int pvpTierId, string @namespace, Region region, Locale locale);
+
+        /// <summary>
+        ///     Get media for a PvP tier by ID.
+        /// </summary>
+        /// <param name="pvpTierId">The PvP tier ID.</param>
+        /// <param name="namespace">The namespace to use to locate this document.</param>
+        /// <returns>
+        ///     Media for a PvP tier by ID.
+        /// </returns>
+        Task<RequestResult<PvpTierMedia>> GetPvpTierMediaAsync(int pvpTierId, string @namespace);
+
+        /// <summary>
+        ///     Get media for a PvP tier by ID.
+        /// </summary>
+        /// <param name="pvpTierId">The PvP tier ID.</param>
+        /// <param name="namespace">The namespace to use to locate this document.</param>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     Media for a PvP tier by ID.
+        /// </returns>
+        Task<RequestResult<PvpTierMedia>> GetPvpTierMediaAsync(int pvpTierId, string @namespace, Region region, Locale locale);
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/PvpSeason/PvpLeaderboardEntry.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/PvpSeason/PvpLeaderboardEntry.cs
@@ -41,6 +41,6 @@ namespace ArgentPonyWarcraftClient
         /// Gets a reference to the character's PvP tier.
         /// </summary>
         [JsonProperty("tier")]
-        public PvpTierReference Tier { get; set; }
+        public PvpTierReferenceWithoutName Tier { get; set; }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/PvpTier/PvpTier.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/PvpTier/PvpTier.cs
@@ -1,0 +1,58 @@
+﻿using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// A PvP tier.
+    /// </summary>
+    public class PvpTier
+    {
+        /// <summary>
+        /// Gets links for the PvP tier.
+        /// </summary>
+        [JsonProperty("_links")]
+        public Links Links { get; set; }
+
+        /// <summary>
+        /// Gets the ID of the PvP tier.
+        /// </summary>
+        [JsonProperty("id")]
+        public long Id { get; set; }
+
+        /// <summary>
+        /// Gets the name of the PvP tier.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets the minimum rating for the PvP tier.
+        /// </summary>
+        [JsonProperty("min_rating")]
+        public long MinRating { get; set; }
+
+        /// <summary>
+        /// Gets the maximum rating for the PvP tier.
+        /// </summary>
+        [JsonProperty("max_rating")]
+        public long MaxRating { get; set; }
+
+        /// <summary>
+        /// Gets the media associated with the PvP tier.
+        /// </summary>
+        [JsonProperty("media")]
+        public Media Media { get; set; }
+
+        /// <summary>
+        /// Gets the bracket for the PvP tier.
+        /// </summary>
+        [JsonProperty("bracket")]
+        public Bracket Bracket { get; set; }
+
+        /// <summary>
+        /// Gets the rating type for the PvP tier.
+        /// </summary>
+        [JsonProperty("rating_type")]
+        public long RatingType { get; set; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/PvpTier/PvpTierMedia.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/PvpTier/PvpTierMedia.cs
@@ -3,21 +3,21 @@
 namespace ArgentPonyWarcraftClient
 {
     /// <summary>
-    /// A reference to a PvP tier.
+    /// PvP tier media.
     /// </summary>
-    public class PvpTierReference
+    public class PvpTierMedia
     {
         /// <summary>
-        /// Gets the key for the PvP tier.
+        /// Gets links for the PvP tier media.
         /// </summary>
-        [JsonProperty("key")]
-        public Self Key { get; set; }
+        [JsonProperty("_links")]
+        public Links Links { get; set; }
 
         /// <summary>
-        /// Gets the name of the PvP tier.
+        /// Gets a collection of media assets.
         /// </summary>
-        [JsonProperty("name")]
-        public string Name { get; set; }
+        [JsonProperty("assets")]
+        public Asset[] Assets { get; set; }
 
         /// <summary>
         /// Gets the ID of the PvP tier.

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/PvpTier/PvpTierReferenceWithoutName.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/PvpTier/PvpTierReferenceWithoutName.cs
@@ -5,19 +5,13 @@ namespace ArgentPonyWarcraftClient
     /// <summary>
     /// A reference to a PvP tier.
     /// </summary>
-    public class PvpTierReference
+    public class PvpTierReferenceWithoutName
     {
         /// <summary>
         /// Gets the key for the PvP tier.
         /// </summary>
         [JsonProperty("key")]
         public Self Key { get; set; }
-
-        /// <summary>
-        /// Gets the name of the PvP tier.
-        /// </summary>
-        [JsonProperty("name")]
-        public string Name { get; set; }
 
         /// <summary>
         /// Gets the ID of the PvP tier.

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/PvpTier/PvpTiersIndex.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/PvpTier/PvpTiersIndex.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// An index of PvP tiers.
+    /// </summary>
+    public class PvpTiersIndex
+    {
+        /// <summary>
+        /// Gets links for the index of PvP tiers.
+        /// </summary>
+        [JsonProperty("_links")]
+        public Links Links { get; set; }
+
+        /// <summary>
+        /// Gets references to the PvP tiers.
+        /// </summary>
+        [JsonProperty("tiers")]
+        public PvpTierReference[] Tiers { get; set; }
+    }
+}

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/PvpTierApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/PvpTierApiTests.cs
@@ -1,0 +1,41 @@
+﻿using ArgentPonyWarcraftClient.Tests.Properties;
+using Xunit;
+
+namespace ArgentPonyWarcraftClient.Tests
+{
+    public class PvpTierApiTests
+    {
+        [Fact]
+        public async void GetPvpTiersIndexAsync_Gets_PvpTiersIndex()
+        {
+            IWarcraftClientPvpTierApi warcraftClient = ClientFactory.BuildMockClient(
+                requestUri: "https://us.api.blizzard.com/data/wow/pvp-tier/index?namespace=static-us&locale=en_US",
+                responseContent: Resources.PvpTiersIndexResponse);
+
+            RequestResult<PvpTiersIndex> result = await warcraftClient.GetPvpTiersIndexAsync("static-us");
+            Assert.NotNull(result.Value);
+        }
+
+        [Fact]
+        public async void GetPvpTierAsync_Gets_PvpTier()
+        {
+            IWarcraftClientPvpTierApi warcraftClient = ClientFactory.BuildMockClient(
+                requestUri: "https://us.api.blizzard.com/data/wow/pvp-tier/1?namespace=static-us&locale=en_US",
+                responseContent: Resources.PvpTierResponse);
+
+            RequestResult<PvpTier> result = await warcraftClient.GetPvpTierAsync(1, "static-us");
+            Assert.NotNull(result.Value);
+        }
+
+        [Fact]
+        public async void GetPvpTierMediaAsync_Gets_PvpTierMedia()
+        {
+            IWarcraftClientPvpTierApi warcraftClient = ClientFactory.BuildMockClient(
+                requestUri: "https://us.api.blizzard.com/data/wow/media/pvp-tier/1?namespace=static-us&locale=en_US",
+                responseContent: Resources.PvpTierMediaResponse);
+
+            RequestResult<PvpTierMedia> result = await warcraftClient.GetPvpTierMediaAsync(1, "static-us");
+            Assert.NotNull(result.Value);
+        }
+    }
+}

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
@@ -1986,6 +1986,86 @@ namespace ArgentPonyWarcraftClient.Tests.Properties {
         ///   Looks up a localized string similar to {
         ///  &quot;_links&quot;: {
         ///    &quot;self&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/media/pvp-tier/1?namespace=static-8.3.0_32861-us&quot;
+        ///    }
+        ///  },
+        ///  &quot;assets&quot;: [
+        ///    {
+        ///      &quot;key&quot;: &quot;icon&quot;,
+        ///      &quot;value&quot;: &quot;https://render-us.worldofwarcraft.com/icons/56/ui_rankedpvp_01.jpg&quot;
+        ///    }
+        ///  ],
+        ///  &quot;id&quot;: 1
+        ///}.
+        /// </summary>
+        internal static string PvpTierMediaResponse {
+            get {
+                return ResourceManager.GetString("PvpTierMediaResponse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {
+        ///  &quot;_links&quot;: {
+        ///    &quot;self&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/pvp-tier/1?namespace=static-8.3.0_32861-us&quot;
+        ///    }
+        ///  },
+        ///  &quot;id&quot;: 1,
+        ///  &quot;name&quot;: &quot;Unranked&quot;,
+        ///  &quot;min_rating&quot;: 0,
+        ///  &quot;max_rating&quot;: 1400,
+        ///  &quot;media&quot;: {
+        ///    &quot;key&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/media/pvp-tier/1?namespace=static-8.3.0_32861-us&quot;
+        ///    },
+        ///    &quot;id&quot;: 1
+        ///  },
+        ///  &quot;bracket&quot;: {
+        ///    &quot;id&quot;: 0,
+        ///    &quot;type&quot;: &quot;ARENA_2v2&quot;
+        ///  },
+        ///  &quot;rating_type&quot;: 0
+        ///}.
+        /// </summary>
+        internal static string PvpTierResponse {
+            get {
+                return ResourceManager.GetString("PvpTierResponse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {
+        ///  &quot;_links&quot;: {
+        ///    &quot;self&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/pvp-tier/?namespace=static-8.3.0_32861-us&quot;
+        ///    }
+        ///  },
+        ///  &quot;tiers&quot;: [
+        ///    {
+        ///      &quot;key&quot;: {
+        ///        &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/pvp-tier/1?namespace=static-8.3.0_32861-us&quot;
+        ///      },
+        ///      &quot;name&quot;: &quot;Unranked&quot;,
+        ///      &quot;id&quot;: 1
+        ///    },
+        ///    {
+        ///      &quot;key&quot;: {
+        ///        &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/pvp-tier/2?namespace=static-8.3.0_32861-us&quot;
+        ///      },
+        ///      &quot;name&quot;: &quot;Combatant&quot;,
+        ///      &quot;id&quot;: 2        /// [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string PvpTiersIndexResponse {
+            get {
+                return ResourceManager.GetString("PvpTiersIndexResponse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {
+        ///  &quot;_links&quot;: {
+        ///    &quot;self&quot;: {
         ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/quest/area/1?namespace=static-8.3.0_32861-us&quot;
         ///    }
         ///  },

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
@@ -62801,4 +62801,181 @@
   }
 }</value>
   </data>
+  <data name="PvpTierMediaResponse" xml:space="preserve">
+    <value>{
+  "_links": {
+    "self": {
+      "href": "https://us.api.blizzard.com/data/wow/media/pvp-tier/1?namespace=static-8.3.0_32861-us"
+    }
+  },
+  "assets": [
+    {
+      "key": "icon",
+      "value": "https://render-us.worldofwarcraft.com/icons/56/ui_rankedpvp_01.jpg"
+    }
+  ],
+  "id": 1
+}</value>
+  </data>
+  <data name="PvpTierResponse" xml:space="preserve">
+    <value>{
+  "_links": {
+    "self": {
+      "href": "https://us.api.blizzard.com/data/wow/pvp-tier/1?namespace=static-8.3.0_32861-us"
+    }
+  },
+  "id": 1,
+  "name": "Unranked",
+  "min_rating": 0,
+  "max_rating": 1400,
+  "media": {
+    "key": {
+      "href": "https://us.api.blizzard.com/data/wow/media/pvp-tier/1?namespace=static-8.3.0_32861-us"
+    },
+    "id": 1
+  },
+  "bracket": {
+    "id": 0,
+    "type": "ARENA_2v2"
+  },
+  "rating_type": 0
+}</value>
+  </data>
+  <data name="PvpTiersIndexResponse" xml:space="preserve">
+    <value>{
+  "_links": {
+    "self": {
+      "href": "https://us.api.blizzard.com/data/wow/pvp-tier/?namespace=static-8.3.0_32861-us"
+    }
+  },
+  "tiers": [
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/pvp-tier/1?namespace=static-8.3.0_32861-us"
+      },
+      "name": "Unranked",
+      "id": 1
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/pvp-tier/2?namespace=static-8.3.0_32861-us"
+      },
+      "name": "Combatant",
+      "id": 2
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/pvp-tier/3?namespace=static-8.3.0_32861-us"
+      },
+      "name": "Challenger",
+      "id": 3
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/pvp-tier/4?namespace=static-8.3.0_32861-us"
+      },
+      "name": "Rival",
+      "id": 4
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/pvp-tier/5?namespace=static-8.3.0_32861-us"
+      },
+      "name": "Duelist",
+      "id": 5
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/pvp-tier/6?namespace=static-8.3.0_32861-us"
+      },
+      "name": "Elite",
+      "id": 6
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/pvp-tier/8?namespace=static-8.3.0_32861-us"
+      },
+      "name": "Unranked",
+      "id": 8
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/pvp-tier/9?namespace=static-8.3.0_32861-us"
+      },
+      "name": "Combatant",
+      "id": 9
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/pvp-tier/11?namespace=static-8.3.0_32861-us"
+      },
+      "name": "Challenger",
+      "id": 11
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/pvp-tier/12?namespace=static-8.3.0_32861-us"
+      },
+      "name": "Rival",
+      "id": 12
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/pvp-tier/13?namespace=static-8.3.0_32861-us"
+      },
+      "name": "Duelist",
+      "id": 13
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/pvp-tier/14?namespace=static-8.3.0_32861-us"
+      },
+      "name": "Elite",
+      "id": 14
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/pvp-tier/16?namespace=static-8.3.0_32861-us"
+      },
+      "name": "Unranked",
+      "id": 16
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/pvp-tier/17?namespace=static-8.3.0_32861-us"
+      },
+      "name": "Combatant",
+      "id": 17
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/pvp-tier/18?namespace=static-8.3.0_32861-us"
+      },
+      "name": "Challenger",
+      "id": 18
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/pvp-tier/19?namespace=static-8.3.0_32861-us"
+      },
+      "name": "Rival",
+      "id": 19
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/pvp-tier/20?namespace=static-8.3.0_32861-us"
+      },
+      "name": "Duelist",
+      "id": 20
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/pvp-tier/21?namespace=static-8.3.0_32861-us"
+      },
+      "name": "Elite",
+      "id": 21
+    }
+  ]
+}</value>
+  </data>
 </root>


### PR DESCRIPTION
Added support for the PvP Tier API.  Added an IWarcraftClientPvpTierApi interface to describe the capabilities of the API.  The IWarcraftClient interface implements this interface via the IWarcraftClientGameDataApi interface.