### PR TITLE
Added support for the Account Profile API

### DIFF
--- a/src/ArgentPonyWarcraftClient/Client/ProfileApi/AccountProfileApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/ProfileApi/AccountProfileApi.cs
@@ -1,0 +1,72 @@
+﻿using System.Threading.Tasks;
+
+namespace ArgentPonyWarcraftClient
+{
+    public partial class WarcraftClient
+    {
+        /// <inheritdoc />
+        public async Task<RequestResult<AccountProfileSummary>> GetAccountProfileSummaryAsync(string accessToken, string @namespace)
+        {
+            return await GetAccountProfileSummaryAsync(accessToken, @namespace, _region, _locale);
+        }
+
+        /// <inheritdoc />
+        public async Task<RequestResult<AccountProfileSummary>> GetAccountProfileSummaryAsync(string accessToken, string @namespace, Region region, Locale locale)
+        {
+            string host = GetHost(region);
+            return await Get<AccountProfileSummary>(region, $"{host}/profile/user/wow?namespace={@namespace}&locale={locale}", accessToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<RequestResult<ProtectedCharacterProfileSummary>> GetProtectedCharacterProfileSummaryAsync(int realmId, int characterId, string accessToken, string @namespace)
+        {
+            return await GetProtectedCharacterProfileSummaryAsync(realmId, characterId, accessToken, @namespace, _region, _locale);
+        }
+
+        /// <inheritdoc />
+        public async Task<RequestResult<ProtectedCharacterProfileSummary>> GetProtectedCharacterProfileSummaryAsync(int realmId, int characterId, string accessToken, string @namespace, Region region, Locale locale)
+        {
+            string host = GetHost(region);
+            return await Get<ProtectedCharacterProfileSummary>(region, $"{host}/profile/user/wow/protected-character/{realmId}-{characterId}?namespace={@namespace}&locale={locale}", accessToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<RequestResult<AccountCollectionsIndex>> GetAccountCollectionsIndexAsync(string accessToken, string @namespace)
+        {
+            return await GetAccountCollectionsIndexAsync(accessToken, @namespace, _region, _locale);
+        }
+
+        /// <inheritdoc />
+        public async Task<RequestResult<AccountCollectionsIndex>> GetAccountCollectionsIndexAsync(string accessToken, string @namespace, Region region, Locale locale)
+        {
+            string host = GetHost(region);
+            return await Get<AccountCollectionsIndex>(region, $"{host}/profile/user/wow/collections?namespace={@namespace}&locale={locale}", accessToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<RequestResult<AccountMountsCollectionSummary>> GetAccountMountsCollectionSummaryAsync(string accessToken, string @namespace)
+        {
+            return await GetAccountMountsCollectionSummaryAsync(accessToken, @namespace, _region, _locale);
+        }
+
+        /// <inheritdoc />
+        public async Task<RequestResult<AccountMountsCollectionSummary>> GetAccountMountsCollectionSummaryAsync(string accessToken, string @namespace, Region region, Locale locale)
+        {
+            string host = GetHost(region);
+            return await Get<AccountMountsCollectionSummary>(region, $"{host}/profile/user/wow/collections/mounts?namespace={@namespace}&locale={locale}", accessToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<RequestResult<AccountPetsCollectionSummary>> GetAccountPetsCollectionSummaryAsync(string accessToken, string @namespace)
+        {
+            return await GetAccountPetsCollectionSummaryAsync(accessToken, @namespace, _region, _locale);
+        }
+
+        /// <inheritdoc />
+        public async Task<RequestResult<AccountPetsCollectionSummary>> GetAccountPetsCollectionSummaryAsync(string accessToken, string @namespace, Region region, Locale locale)
+        {
+            string host = GetHost(region);
+            return await Get<AccountPetsCollectionSummary>(region, $"{host}/profile/user/wow/collections/pets?namespace={@namespace}&locale={locale}", accessToken);
+        }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Interfaces/ProfileApi/IAccountProfileApi.cs
+++ b/src/ArgentPonyWarcraftClient/Interfaces/ProfileApi/IAccountProfileApi.cs
@@ -1,0 +1,124 @@
+﻿using System.Threading.Tasks;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    ///     A client for the World of Warcraft Character Profile API.
+    /// </summary>
+    public interface IAccountProfileApi
+    {
+        /// <summary>
+        ///     Get a profile summary for an account.
+        /// </summary>
+        /// <param name="accessToken">The OAuth access token for the user.</param>
+        /// <param name="namespace">The namespace to use to locate this document.</param>
+        /// <returns>
+        ///     The profile summary for the account.
+        /// </returns>
+        Task<RequestResult<AccountProfileSummary>> GetAccountProfileSummaryAsync(string accessToken, string @namespace);
+
+        /// <summary>
+        ///     Get a profile summary for an account.
+        /// </summary>
+        /// <param name="accessToken">The OAuth access token for the user.</param>
+        /// <param name="namespace">The namespace to use to locate this document.</param>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     The profile summary for the account.
+        /// </returns>
+        Task<RequestResult<AccountProfileSummary>> GetAccountProfileSummaryAsync(string accessToken, string @namespace, Region region, Locale locale);
+
+        /// <summary>
+        ///     Get a protected profile summary for a character.
+        /// </summary>
+        /// <param name="realmId">The ID of the character's realm.</param>
+        /// <param name="characterId">The ID of the character.</param>
+        /// <param name="accessToken">The OAuth access token for the user.</param>
+        /// <param name="namespace">The namespace to use to locate this document.</param>
+        /// <returns>
+        ///     The protected profile summary for the character.
+        /// </returns>
+        Task<RequestResult<ProtectedCharacterProfileSummary>> GetProtectedCharacterProfileSummaryAsync(int realmId, int characterId, string accessToken, string @namespace);
+
+        /// <summary>
+        ///     Get a protected profile summary for a character.
+        /// </summary>
+        /// <param name="realmId">The ID of the character's realm.</param>
+        /// <param name="characterId">The ID of the character.</param>
+        /// <param name="accessToken">The OAuth access token for the user.</param>
+        /// <param name="namespace">The namespace to use to locate this document.</param>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     The protected profile summary for the character.
+        /// </returns>
+        Task<RequestResult<ProtectedCharacterProfileSummary>> GetProtectedCharacterProfileSummaryAsync(int realmId, int characterId, string accessToken, string @namespace, Region region, Locale locale);
+
+        /// <summary>
+        ///     Get an index of collection types for an account.
+        /// </summary>
+        /// <param name="accessToken">The OAuth access token for the user.</param>
+        /// <param name="namespace">The namespace to use to locate this document.</param>
+        /// <returns>
+        ///     An index of collection types for the account.
+        /// </returns>
+        Task<RequestResult<AccountCollectionsIndex>> GetAccountCollectionsIndexAsync(string accessToken, string @namespace);
+
+        /// <summary>
+        ///     Get an index of collection types for an account.
+        /// </summary>
+        /// <param name="accessToken">The OAuth access token for the user.</param>
+        /// <param name="namespace">The namespace to use to locate this document.</param>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     An index of collection types for the account.
+        /// </returns>
+        Task<RequestResult<AccountCollectionsIndex>> GetAccountCollectionsIndexAsync(string accessToken, string @namespace, Region region, Locale locale);
+
+        /// <summary>
+        ///     Get a summary of the mounts an account has obtained.
+        /// </summary>
+        /// <param name="accessToken">The OAuth access token for the user.</param>
+        /// <param name="namespace">The namespace to use to locate this document.</param>
+        /// <returns>
+        ///     A summary of the mounts the account has obtained.
+        /// </returns>
+        Task<RequestResult<AccountMountsCollectionSummary>> GetAccountMountsCollectionSummaryAsync(string accessToken, string @namespace);
+
+        /// <summary>
+        ///     Get a summary of the mounts an account has obtained.
+        /// </summary>
+        /// <param name="accessToken">The OAuth access token for the user.</param>
+        /// <param name="namespace">The namespace to use to locate this document.</param>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     A summary of the mounts the account has obtained.
+        /// </returns>
+        Task<RequestResult<AccountMountsCollectionSummary>> GetAccountMountsCollectionSummaryAsync(string accessToken, string @namespace, Region region, Locale locale);
+
+        /// <summary>
+        ///     Get a summary of the battle pets an account has obtained.
+        /// </summary>
+        /// <param name="accessToken">The OAuth access token for the user.</param>
+        /// <param name="namespace">The namespace to use to locate this document.</param>
+        /// <returns>
+        ///     A summary of the battle pets the account has obtained.
+        /// </returns>
+        Task<RequestResult<AccountPetsCollectionSummary>> GetAccountPetsCollectionSummaryAsync(string accessToken, string @namespace);
+
+        /// <summary>
+        ///     Get a summary of the battle pets an account has obtained.
+        /// </summary>
+        /// <param name="accessToken">The OAuth access token for the user.</param>
+        /// <param name="namespace">The namespace to use to locate this document.</param>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     A summary of the battle pets the account has obtained.
+        /// </returns>
+        Task<RequestResult<AccountPetsCollectionSummary>> GetAccountPetsCollectionSummaryAsync(string accessToken, string @namespace, Region region, Locale locale);
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Interfaces/ProfileApi/IProfileApi.cs
+++ b/src/ArgentPonyWarcraftClient/Interfaces/ProfileApi/IProfileApi.cs
@@ -4,6 +4,7 @@
     ///     A client for the World of Warcraft Profile APIs.
     /// </summary>
     public interface IProfileApi :
+        IAccountProfileApi,
         ICharacterAchievementsApi,
         ICharacterAppearanceApi,
         ICharacterCollectionsApi,

--- a/src/ArgentPonyWarcraftClient/Models/ProfileApi/AccountProfile/AccountCharacter.cs
+++ b/src/ArgentPonyWarcraftClient/Models/ProfileApi/AccountProfile/AccountCharacter.cs
@@ -1,0 +1,70 @@
+﻿using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// A character associated with a World of Warcraft account.
+    /// </summary>
+    public class AccountCharacter
+    {
+        /// <summary>
+        /// Gets a link to the character.
+        /// </summary>
+        [JsonProperty("character")]
+        public Self Character { get; set; }
+
+        /// <summary>
+        /// Gets a link to the protected character information.
+        /// </summary>
+        [JsonProperty("protected_character")]
+        public Self ProtectedCharacter { get; set; }
+
+        /// <summary>
+        /// Gets the name of the character.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets the ID of the character.
+        /// </summary>
+        [JsonProperty("id")]
+        public long Id { get; set; }
+
+        /// <summary>
+        /// Gets a reference to the character's realm.
+        /// </summary>
+        [JsonProperty("realm")]
+        public RealmReference Realm { get; set; }
+
+        /// <summary>
+        /// Gets a reference to the character's class.
+        /// </summary>
+        [JsonProperty("playable_class")]
+        public PlayableClassReference PlayableClass { get; set; }
+
+        /// <summary>
+        /// Gets a reference to the character's race.
+        /// </summary>
+        [JsonProperty("playable_race")]
+        public PlayableClassReference PlayableRace { get; set; }
+
+        /// <summary>
+        /// Gets the gender of the character.
+        /// </summary>
+        [JsonProperty("gender")]
+        public EnumType Gender { get; set; }
+
+        /// <summary>
+        /// Gets the faction of the character (Alliance or Horde).
+        /// </summary>
+        [JsonProperty("faction")]
+        public EnumType Faction { get; set; }
+
+        /// <summary>
+        /// Gets the level of the character.
+        /// </summary>
+        [JsonProperty("level")]
+        public long Level { get; set; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/ProfileApi/AccountProfile/AccountCollectionsIndex.cs
+++ b/src/ArgentPonyWarcraftClient/Models/ProfileApi/AccountProfile/AccountCollectionsIndex.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// An index of collection types for an account.
+    /// </summary>
+    public class AccountCollectionsIndex
+    {
+        /// <summary>
+        /// Gets links for the index of collection types for the account.
+        /// </summary>
+        [JsonProperty("_links")]
+        public LinksForAccountProfile Links { get; set; }
+
+        /// <summary>
+        /// Gets a link to the pets collection for the account.
+        /// </summary>
+        [JsonProperty("pets")]
+        public Self Pets { get; set; }
+
+        /// <summary>
+        /// Gets a link to the mounts collection for the account.
+        /// </summary>
+        [JsonProperty("mounts")]
+        public Self Mounts { get; set; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/ProfileApi/AccountProfile/AccountMount.cs
+++ b/src/ArgentPonyWarcraftClient/Models/ProfileApi/AccountProfile/AccountMount.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// A mount belonging to a World of Warcraft account.
+    /// </summary>
+    public class AccountMount
+    {
+        /// <summary>
+        /// Gets a reference to the mount.
+        /// </summary>
+        [JsonProperty("mount")]
+        public MountReference Mount { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the mount is a favorite.
+        /// </summary>
+        [JsonProperty("is_favorite", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? IsFavorite { get; set; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/ProfileApi/AccountProfile/AccountMountsCollectionSummary.cs
+++ b/src/ArgentPonyWarcraftClient/Models/ProfileApi/AccountProfile/AccountMountsCollectionSummary.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// A summary of the mounts an account has obtained.
+    /// </summary>
+    public class AccountMountsCollectionSummary
+    {
+        /// <summary>
+        /// Gets links for the summary of the mounts the account has obtained.
+        /// </summary>
+        [JsonProperty("_links")]
+        public LinksForAccountProfile Links { get; set; }
+
+        /// <summary>
+        /// Gets the mounts for the account.
+        /// </summary>
+        [JsonProperty("mounts")]
+        public AccountMount[] Mounts { get; set; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/ProfileApi/AccountProfile/AccountPet.cs
+++ b/src/ArgentPonyWarcraftClient/Models/ProfileApi/AccountProfile/AccountPet.cs
@@ -1,0 +1,64 @@
+﻿namespace ArgentPonyWarcraftClient
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// A battle pet belonging to a World of Warcraft account.
+    /// </summary>
+    public class AccountPet
+    {
+        /// <summary>
+        /// Gets a reference to the species of the pet.
+        /// </summary>
+        [JsonProperty("species")]
+        public PetReference Species { get; set; }
+
+        /// <summary>
+        /// Gets the level of the pet.
+        /// </summary>
+        [JsonProperty("level")]
+        public long Level { get; set; }
+
+        /// <summary>
+        /// Gets the quality of the pet.
+        /// </summary>
+        [JsonProperty("quality")]
+        public EnumType Quality { get; set; }
+
+        /// <summary>
+        /// Gets the pet stats.
+        /// </summary>
+        [JsonProperty("stats")]
+        public PetStats Stats { get; set; }
+
+        /// <summary>
+        /// Gets a reference to the creature display media for the pet.
+        /// </summary>
+        [JsonProperty("creature_display", NullValueHandling = NullValueHandling.Ignore)]
+        public CreatureDisplayMediaReference CreatureDisplay { get; set; }
+
+        /// <summary>
+        /// Gets the ID of the pet.
+        /// </summary>
+        [JsonProperty("id")]
+        public long Id { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the pet is a favorite.
+        /// </summary>
+        [JsonProperty("is_favorite", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? IsFavorite { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the pet is currently active.
+        /// </summary>
+        [JsonProperty("is_active", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? IsActive { get; set; }
+
+        /// <summary>
+        /// Gets the slot number if the pet is currently active.
+        /// </summary>
+        [JsonProperty("active_slot", NullValueHandling = NullValueHandling.Ignore)]
+        public long? ActiveSlot { get; set; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/ProfileApi/AccountProfile/AccountPetsCollectionSummary.cs
+++ b/src/ArgentPonyWarcraftClient/Models/ProfileApi/AccountProfile/AccountPetsCollectionSummary.cs
@@ -1,0 +1,28 @@
+﻿namespace ArgentPonyWarcraftClient
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// A summary of the battle pets an account has obtained.
+    /// </summary>
+    public class AccountPetsCollectionSummary
+    {
+        /// <summary>
+        /// Gets links for the summary of the battle pets the account has obtained.
+        /// </summary>
+        [JsonProperty("_links")]
+        public LinksForAccountProfile Links { get; set; }
+
+        /// <summary>
+        /// Gets the battle pets for the account.
+        /// </summary>
+        [JsonProperty("pets")]
+        public AccountPet[] Pets { get; set; }
+
+        /// <summary>
+        /// Gets the number of battle pet slots the account has unlocked.
+        /// </summary>
+        [JsonProperty("unlocked_battle_pet_slots")]
+        public long UnlockedBattlePetSlots { get; set; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/ProfileApi/AccountProfile/AccountProfileSummary.cs
+++ b/src/ArgentPonyWarcraftClient/Models/ProfileApi/AccountProfile/AccountProfileSummary.cs
@@ -1,0 +1,34 @@
+﻿using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// A profile summary for an account.
+    /// </summary>
+    public class AccountProfileSummary
+    {
+        /// <summary>
+        /// Gets links for the profile summary for the account.
+        /// </summary>
+        [JsonProperty("_links")]
+        public LinksForAccountProfile Links { get; set; }
+
+        /// <summary>
+        /// Gets the ID of the profile summary for the account.
+        /// </summary>
+        [JsonProperty("id")]
+        public long Id { get; set; }
+
+        /// <summary>
+        /// Gets the World of Warcraft accounts associated with the account profile.
+        /// </summary>
+        [JsonProperty("wow_accounts")]
+        public WowAccount[] WowAccounts { get; set; }
+
+        /// <summary>
+        /// Gets a link to the collections for the account.
+        /// </summary>
+        [JsonProperty("collections")]
+        public Self Collections { get; set; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/ProfileApi/AccountProfile/LinksForAccountProfile.cs
+++ b/src/ArgentPonyWarcraftClient/Models/ProfileApi/AccountProfile/LinksForAccountProfile.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// Links associated with a user profile.
+    /// </summary>
+    public class LinksForAccountProfile
+    {
+        /// <summary>
+        /// Gets a self-reference.
+        /// </summary>
+        [JsonProperty("self")]
+        public Self Self { get; set; }
+
+        /// <summary>
+        /// Gets a link to the user.
+        /// </summary>
+        [JsonProperty("user")]
+        public Self User { get; set; }
+
+        /// <summary>
+        /// Gets a link to the profile.
+        /// </summary>
+        [JsonProperty("profile")]
+        public Self Profile { get; set; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/ProfileApi/AccountProfile/Position.cs
+++ b/src/ArgentPonyWarcraftClient/Models/ProfileApi/AccountProfile/Position.cs
@@ -1,0 +1,46 @@
+﻿using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// A position in the game.
+    /// </summary>
+    public class Position
+    {
+        /// <summary>
+        /// Gets the zone.
+        /// </summary>
+        [JsonProperty("zone")]
+        public Map Zone { get; set; }
+
+        /// <summary>
+        /// Gets the map.
+        /// </summary>
+        [JsonProperty("map")]
+        public Map Map { get; set; }
+
+        /// <summary>
+        /// Gets the x coordinate.
+        /// </summary>
+        [JsonProperty("x")]
+        public double X { get; set; }
+
+        /// <summary>
+        /// Gets the y coordinate.
+        /// </summary>
+        [JsonProperty("y")]
+        public double Y { get; set; }
+
+        /// <summary>
+        /// Gets the z coordinate.
+        /// </summary>
+        [JsonProperty("z")]
+        public double Z { get; set; }
+
+        /// <summary>
+        /// Gets the facing.
+        /// </summary>
+        [JsonProperty("facing")]
+        public double Facing { get; set; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/ProfileApi/AccountProfile/ProtectedCharacterProfileSummary.cs
+++ b/src/ArgentPonyWarcraftClient/Models/ProfileApi/AccountProfile/ProtectedCharacterProfileSummary.cs
@@ -1,0 +1,64 @@
+﻿using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// A protected profile summary for a character.
+    /// </summary>
+    public class ProtectedCharacterProfileSummary
+    {
+        /// <summary>
+        /// Gets links for the protected profile summary for the character.
+        /// </summary>
+        [JsonProperty("_links")]
+        public LinksForAccountProfile Links { get; set; }
+
+        /// <summary>
+        /// Gets the ID of the character.
+        /// </summary>
+        [JsonProperty("id")]
+        public long Id { get; set; }
+
+        /// <summary>
+        /// Gets the name of the character.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets the amount of money owned by the character.
+        /// </summary>
+        [JsonProperty("money")]
+        public long Money { get; set; }
+
+        /// <summary>
+        /// Gets a reference to the character.
+        /// </summary>
+        [JsonProperty("character")]
+        public CharacterReference Character { get; set; }
+
+        /// <summary>
+        /// Gets the protected statistics for the character.
+        /// </summary>
+        [JsonProperty("protected_stats")]
+        public ProtectedStats ProtectedStats { get; set; }
+
+        /// <summary>
+        /// Gets the character's current position.
+        /// </summary>
+        [JsonProperty("position")]
+        public Position Position { get; set; }
+
+        /// <summary>
+        /// Gets the bind position of the character's hearthstone.
+        /// </summary>
+        [JsonProperty("bind_position")]
+        public Position BindPosition { get; set; }
+
+        /// <summary>
+        /// Gets the WoW account for the character.
+        /// </summary>
+        [JsonProperty("wow_account")]
+        public long WowAccount { get; set; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/ProfileApi/AccountProfile/ProtectedStats.cs
+++ b/src/ArgentPonyWarcraftClient/Models/ProfileApi/AccountProfile/ProtectedStats.cs
@@ -1,0 +1,58 @@
+﻿using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// Protected statistics for a character.
+    /// </summary>
+    public class ProtectedStats
+    {
+        /// <summary>
+        /// Gets the total number of deaths for the character.
+        /// </summary>
+        [JsonProperty("total_number_deaths")]
+        public long TotalNumberDeaths { get; set; }
+
+        /// <summary>
+        /// Gets the total gold gained by the character.
+        /// </summary>
+        [JsonProperty("total_gold_gained")]
+        public long TotalGoldGained { get; set; }
+
+        /// <summary>
+        /// Gets the total gold lost by the character.
+        /// </summary>
+        [JsonProperty("total_gold_lost")]
+        public long TotalGoldLost { get; set; }
+
+        /// <summary>
+        /// Gets the total item value gained by the character.
+        /// </summary>
+        [JsonProperty("total_item_value_gained")]
+        public long TotalItemValueGained { get; set; }
+
+        /// <summary>
+        /// Gets the number of deaths at this level for the character.
+        /// </summary>
+        [JsonProperty("level_number_deaths")]
+        public long LevelNumberDeaths { get; set; }
+
+        /// <summary>
+        /// Gets the gold gained at this level by the character.
+        /// </summary>
+        [JsonProperty("level_gold_gained")]
+        public long LevelGoldGained { get; set; }
+
+        /// <summary>
+        /// Gets the gold lost at this level by the character.
+        /// </summary>
+        [JsonProperty("level_gold_lost")]
+        public long LevelGoldLost { get; set; }
+
+        /// <summary>
+        /// Gets the item value gained at this level by the character.
+        /// </summary>
+        [JsonProperty("level_item_value_gained")]
+        public long LevelItemValueGained { get; set; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/ProfileApi/AccountProfile/WowAccount.cs
+++ b/src/ArgentPonyWarcraftClient/Models/ProfileApi/AccountProfile/WowAccount.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// A World of Warcraft account.
+    /// </summary>
+    public class WowAccount
+    {
+        /// <summary>
+        /// Gets the ID of the World of Warcraft account.
+        /// </summary>
+        [JsonProperty("id")]
+        public long Id { get; set; }
+
+        /// <summary>
+        /// Gets the characters associated with the World of Warcraft account.
+        /// </summary>
+        [JsonProperty("characters")]
+        public AccountCharacter[] Characters { get; set; }
+    }
+}

--- a/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/AccountProfileApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/AccountProfileApiTests.cs
@@ -1,0 +1,63 @@
+﻿using ArgentPonyWarcraftClient.Tests.Properties;
+using Xunit;
+
+namespace ArgentPonyWarcraftClient.Tests.ProfileApi
+{
+    public class AccountProfileApiTests
+    {
+        [Fact]
+        public async void GetAccountProfileSummaryAsync_Gets_AccountProfileSummary()
+        {
+            IAccountProfileApi warcraftClient = ClientFactory.BuildMockClient(
+                requestUri: "https://us.api.blizzard.com/profile/user/wow?namespace=profile-us&locale=en_US",
+                responseContent: Resources.AccountProfileSummaryResponse);
+
+            RequestResult<AccountProfileSummary> result = await warcraftClient.GetAccountProfileSummaryAsync("ACCESS-TOKEN-GOES-HERE", "profile-us");
+            Assert.NotNull(result.Value);
+        }
+
+        [Fact]
+        public async void GetProtectedCharacterProfileSummaryAsync_Gets_ProtectedCharacterProfileSummary()
+        {
+            IAccountProfileApi warcraftClient = ClientFactory.BuildMockClient(
+                requestUri: "https://us.api.blizzard.com/profile/user/wow/protected-character/1262-107811065?namespace=profile-us&locale=en_US",
+                responseContent: Resources.ProtectedCharacterProfileSummaryResponse);
+
+            RequestResult<ProtectedCharacterProfileSummary> result = await warcraftClient.GetProtectedCharacterProfileSummaryAsync(1262, 107811065, "ACCESS-TOKEN-GOES-HERE", "profile-us");
+            Assert.NotNull(result.Value);
+        }
+
+        [Fact]
+        public async void GetAccountCollectionsIndexAsync_Gets_AccountCollectionsIndex()
+        {
+            IAccountProfileApi warcraftClient = ClientFactory.BuildMockClient(
+                requestUri: "https://us.api.blizzard.com/profile/user/wow/collections?namespace=profile-us&locale=en_US",
+                responseContent: Resources.AccountCollectionsIndexResponse);
+
+            RequestResult<AccountCollectionsIndex> result = await warcraftClient.GetAccountCollectionsIndexAsync("ACCESS-TOKEN-GOES-HERE", "profile-us");
+            Assert.NotNull(result.Value);
+        }
+
+        [Fact]
+        public async void GetAccountMountsCollectionSummaryAsync_Gets_AccountMountsCollectionSummary()
+        {
+            IAccountProfileApi warcraftClient = ClientFactory.BuildMockClient(
+                requestUri: "https://us.api.blizzard.com/profile/user/wow/collections/mounts?namespace=profile-us&locale=en_US",
+                responseContent: Resources.AccountMountsCollectionSummaryResponse);
+
+            RequestResult<AccountMountsCollectionSummary> result = await warcraftClient.GetAccountMountsCollectionSummaryAsync("ACCESS-TOKEN-GOES-HERE", "profile-us");
+            Assert.NotNull(result.Value);
+        }
+
+        [Fact]
+        public async void GetAccountPetsCollectionSummaryAsync_Gets_AccountPetsCollectionSummary()
+        {
+            IAccountProfileApi warcraftClient = ClientFactory.BuildMockClient(
+                requestUri: "https://us.api.blizzard.com/profile/user/wow/collections/pets?namespace=profile-us&locale=en_US",
+                responseContent: Resources.AccountPetsCollectionSummaryResponse);
+
+            RequestResult<AccountPetsCollectionSummary> result = await warcraftClient.GetAccountPetsCollectionSummaryAsync("ACCESS-TOKEN-GOES-HERE", "profile-us");
+            Assert.NotNull(result.Value);
+        }
+    }
+}

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
@@ -61,11 +61,118 @@ namespace ArgentPonyWarcraftClient.Tests.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {
+        ///  &quot;_links&quot;: {
+        ///    &quot;self&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/profile/user/wow/collections?namespace=profile-us&quot;
+        ///    },
+        ///    &quot;user&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/profile/user&quot;
+        ///    },
+        ///    &quot;profile&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/profile/user/wow?namespace=profile-us&quot;
+        ///    }
+        ///  },
+        ///  &quot;pets&quot;: {
+        ///    &quot;href&quot;: &quot;https://us.api.blizzard.com/profile/user/wow/collections/pets?namespace=profile-us&quot;
+        ///  },
+        ///  &quot;mounts&quot;: {
+        ///    &quot;href&quot;: &quot;https://us.api.blizzard.com/profile/ [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string AccountCollectionsIndexResponse {
+            get {
+                return ResourceManager.GetString("AccountCollectionsIndexResponse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {&quot;code&quot;:403, &quot;type&quot;:&quot;Forbidden&quot;, &quot;detail&quot;:&quot;Account Inactive&quot;}.
         /// </summary>
         internal static string AccountInactive403ForbiddenResponse {
             get {
                 return ResourceManager.GetString("AccountInactive403ForbiddenResponse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {
+        ///  &quot;_links&quot;: {
+        ///    &quot;self&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/profile/user/wow/collections/mounts?namespace=profile-us&quot;
+        ///    },
+        ///    &quot;user&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/profile/user&quot;
+        ///    },
+        ///    &quot;profile&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/profile/user/wow?namespace=profile-us&quot;
+        ///    }
+        ///  },
+        ///  &quot;mounts&quot;: [
+        ///    {
+        ///      &quot;mount&quot;: {
+        ///        &quot;key&quot;: {
+        ///          &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/mount/6?namespace=static-8.3.0_32861-us&quot;
+        ///        },
+        ///       [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string AccountMountsCollectionSummaryResponse {
+            get {
+                return ResourceManager.GetString("AccountMountsCollectionSummaryResponse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {
+        ///  &quot;_links&quot;: {
+        ///    &quot;self&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/profile/user/wow/collections/pets?namespace=profile-us&quot;
+        ///    },
+        ///    &quot;user&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/profile/user&quot;
+        ///    },
+        ///    &quot;profile&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/profile/user/wow?namespace=profile-us&quot;
+        ///    }
+        ///  },
+        ///  &quot;pets&quot;: [
+        ///    {
+        ///      &quot;species&quot;: {
+        ///        &quot;key&quot;: {
+        ///          &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/pet/202?namespace=static-8.3.0_32861-us&quot;
+        ///        },
+        ///         [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string AccountPetsCollectionSummaryResponse {
+            get {
+                return ResourceManager.GetString("AccountPetsCollectionSummaryResponse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {
+        ///  &quot;_links&quot;: {
+        ///    &quot;self&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/profile/user/wow?namespace=profile-us&quot;
+        ///    },
+        ///    &quot;user&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/profile/user&quot;
+        ///    },
+        ///    &quot;profile&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/profile/user/wow?namespace=profile-us&quot;
+        ///    }
+        ///  },
+        ///  &quot;id&quot;: 1142637,
+        ///  &quot;wow_accounts&quot;: [
+        ///    {
+        ///      &quot;id&quot;: 19995845,
+        ///      &quot;characters&quot;: [
+        ///        {
+        ///          &quot;character&quot;: {
+        ///            &quot;href&quot;: &quot;https://us.api.blizzard.com/profile/wow/cha [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string AccountProfileSummaryResponse {
+            get {
+                return ResourceManager.GetString("AccountProfileSummaryResponse", resourceCulture);
             }
         }
         
@@ -2577,6 +2684,32 @@ namespace ArgentPonyWarcraftClient.Tests.Properties {
         internal static string ProfessionsIndexResponse {
             get {
                 return ResourceManager.GetString("ProfessionsIndexResponse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {
+        ///  &quot;_links&quot;: {
+        ///    &quot;self&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/profile/user/wow/protected-character/1262-107811065?namespace=profile-us&quot;
+        ///    },
+        ///    &quot;user&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/profile/user&quot;
+        ///    },
+        ///    &quot;profile&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/profile/user/wow?namespace=profile-us&quot;
+        ///    }
+        ///  },
+        ///  &quot;id&quot;: 107811065,
+        ///  &quot;name&quot;: &quot;Drinian&quot;,
+        ///  &quot;money&quot;: 1466691688,
+        ///  &quot;character&quot;: {
+        ///    &quot;key&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/profile/wow/chara [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string ProtectedCharacterProfileSummaryResponse {
+            get {
+                return ResourceManager.GetString("ProtectedCharacterProfileSummaryResponse", resourceCulture);
             }
         }
         

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
@@ -73148,4 +73148,397 @@
   }
 }</value>
   </data>
+  <data name="AccountProfileSummaryResponse" xml:space="preserve">
+    <value>{
+  "_links": {
+    "self": {
+      "href": "https://us.api.blizzard.com/profile/user/wow?namespace=profile-us"
+    },
+    "user": {
+      "href": "https://us.api.blizzard.com/profile/user"
+    },
+    "profile": {
+      "href": "https://us.api.blizzard.com/profile/user/wow?namespace=profile-us"
+    }
+  },
+  "id": 1142637,
+  "wow_accounts": [
+    {
+      "id": 19995845,
+      "characters": [
+        {
+          "character": {
+            "href": "https://us.api.blizzard.com/profile/wow/character/darrowmere/bregal932b58?namespace=profile-us"
+          },
+          "protected_character": {
+            "href": "https://us.api.blizzard.com/profile/user/wow/protected-character/1351-93420968?namespace=profile-us"
+          },
+          "name": "Bregal932B58",
+          "id": 93530968,
+          "realm": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/realm/1351?namespace=dynamic-us"
+            },
+            "name": "Darrowmere",
+            "id": 1351,
+            "slug": "darrowmere"
+          },
+          "playable_class": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/playable-class/3?namespace=static-8.3.0_32861-us"
+            },
+            "name": "Hunter",
+            "id": 3
+          },
+          "playable_race": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/playable-race/6?namespace=static-8.3.0_32861-us"
+            },
+            "name": "Tauren",
+            "id": 6
+          },
+          "gender": {
+            "type": "MALE",
+            "name": "Male"
+          },
+          "faction": {
+            "type": "HORDE",
+            "name": "Horde"
+          },
+          "level": 0
+        },
+        {
+          "character": {
+            "href": "https://us.api.blizzard.com/profile/wow/character/steamwheedle-cartel/rilian?namespace=profile-us"
+          },
+          "protected_character": {
+            "href": "https://us.api.blizzard.com/profile/user/wow/protected-character/1270-187342265?namespace=profile-us"
+          },
+          "name": "Rilian",
+          "id": 187393265,
+          "realm": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/realm/1260?namespace=dynamic-us"
+            },
+            "name": "Steamwheedle Cartel",
+            "id": 1260,
+            "slug": "steamwheedle-cartel"
+          },
+          "playable_class": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/playable-class/2?namespace=static-8.3.0_32861-us"
+            },
+            "name": "Paladin",
+            "id": 2
+          },
+          "playable_race": {
+            "key": {
+              "href": "https://us.api.blizzard.com/data/wow/playable-race/1?namespace=static-8.3.0_32861-us"
+            },
+            "name": "Human",
+            "id": 1
+          },
+          "gender": {
+            "type": "MALE",
+            "name": "Male"
+          },
+          "faction": {
+            "type": "ALLIANCE",
+            "name": "Alliance"
+          },
+          "level": 6
+        }
+      ]
+    }
+  ],
+  "collections": {
+    "href": "https://us.api.blizzard.com/profile/user/wow/collections?namespace=profile-us"
+  }
+}</value>
+  </data>
+  <data name="AccountCollectionsIndexResponse" xml:space="preserve">
+    <value>{
+  "_links": {
+    "self": {
+      "href": "https://us.api.blizzard.com/profile/user/wow/collections?namespace=profile-us"
+    },
+    "user": {
+      "href": "https://us.api.blizzard.com/profile/user"
+    },
+    "profile": {
+      "href": "https://us.api.blizzard.com/profile/user/wow?namespace=profile-us"
+    }
+  },
+  "pets": {
+    "href": "https://us.api.blizzard.com/profile/user/wow/collections/pets?namespace=profile-us"
+  },
+  "mounts": {
+    "href": "https://us.api.blizzard.com/profile/user/wow/collections/mounts?namespace=profile-us"
+  }
+}</value>
+  </data>
+  <data name="AccountMountsCollectionSummaryResponse" xml:space="preserve">
+    <value>{
+  "_links": {
+    "self": {
+      "href": "https://us.api.blizzard.com/profile/user/wow/collections/mounts?namespace=profile-us"
+    },
+    "user": {
+      "href": "https://us.api.blizzard.com/profile/user"
+    },
+    "profile": {
+      "href": "https://us.api.blizzard.com/profile/user/wow?namespace=profile-us"
+    }
+  },
+  "mounts": [
+    {
+      "mount": {
+        "key": {
+          "href": "https://us.api.blizzard.com/data/wow/mount/6?namespace=static-8.3.0_32861-us"
+        },
+        "name": "Brown Horse",
+        "id": 6
+      }
+    },
+    {
+      "mount": {
+        "key": {
+          "href": "https://us.api.blizzard.com/data/wow/mount/9?namespace=static-8.3.0_32861-us"
+        },
+        "name": "Black Stallion",
+        "id": 9
+      }
+    },
+    {
+      "mount": {
+        "key": {
+          "href": "https://us.api.blizzard.com/data/wow/mount/1239?namespace=static-8.3.0_32861-us"
+        },
+        "name": "X-995 Mechanocat",
+        "id": 1239
+      },
+      "is_favorite": true
+    },
+    {
+      "mount": {
+        "key": {
+          "href": "https://us.api.blizzard.com/data/wow/mount/1240?namespace=static-8.3.0_32861-us"
+        },
+        "name": "Obsidian Worldbreaker",
+        "id": 1240
+      },
+      "is_favorite": true
+    },
+    {
+      "mount": {
+        "key": {
+          "href": "https://us.api.blizzard.com/data/wow/mount/1253?namespace=static-8.3.0_32861-us"
+        },
+        "name": "Scrapforged Mechaspider",
+        "id": 1253
+      }
+    }
+  ]
+}</value>
+  </data>
+  <data name="AccountPetsCollectionSummaryResponse" xml:space="preserve">
+    <value>{
+  "_links": {
+    "self": {
+      "href": "https://us.api.blizzard.com/profile/user/wow/collections/pets?namespace=profile-us"
+    },
+    "user": {
+      "href": "https://us.api.blizzard.com/profile/user"
+    },
+    "profile": {
+      "href": "https://us.api.blizzard.com/profile/user/wow?namespace=profile-us"
+    }
+  },
+  "pets": [
+    {
+      "species": {
+        "key": {
+          "href": "https://us.api.blizzard.com/data/wow/pet/202?namespace=static-8.3.0_32861-us"
+        },
+        "name": "Baby Blizzard Bear",
+        "id": 202
+      },
+      "level": 1,
+      "quality": {
+        "type": "UNCOMMON",
+        "name": "Uncommon"
+      },
+      "stats": {
+        "breed_id": 7,
+        "health": 153,
+        "power": 11,
+        "speed": 10
+      },
+      "creature_display": {
+        "key": {
+          "href": "https://us.api.blizzard.com/data/wow/media/creature-display/16189?namespace=static-8.3.0_32861-us"
+        },
+        "id": 16189
+      },
+      "id": 57110618
+    },
+    {
+      "species": {
+        "key": {
+          "href": "https://us.api.blizzard.com/data/wow/pet/78?namespace=static-8.3.0_32861-us"
+        },
+        "name": "Crimson Snake",
+        "id": 78
+      },
+      "level": 1,
+      "quality": {
+        "type": "UNCOMMON",
+        "name": "Uncommon"
+      },
+      "stats": {
+        "breed_id": 12,
+        "health": 150,
+        "power": 11,
+        "speed": 10
+      },
+      "creature_display": {
+        "key": {
+          "href": "https://us.api.blizzard.com/data/wow/media/creature-display/6303?namespace=static-8.3.0_32861-us"
+        },
+        "id": 6303
+      },
+      "id": 57110619
+    },
+    {
+      "species": {
+        "key": {
+          "href": "https://us.api.blizzard.com/data/wow/pet/730?namespace=static-8.3.0_32861-us"
+        },
+        "name": "Tolai Hare Pup",
+        "id": 730
+      },
+      "level": 23,
+      "quality": {
+        "type": "UNCOMMON",
+        "name": "Uncommon"
+      },
+      "stats": {
+        "breed_id": 12,
+        "health": 1328,
+        "power": 204,
+        "speed": 259
+      },
+      "is_active": true,
+      "active_slot": 1,
+      "creature_display": {
+        "key": {
+          "href": "https://us.api.blizzard.com/data/wow/media/creature-display/28998?namespace=static-8.3.0_32861-us"
+        },
+        "id": 28998
+      },
+      "id": 57110887
+    },
+    {
+      "species": {
+        "key": {
+          "href": "https://us.api.blizzard.com/data/wow/pet/1922?namespace=static-8.3.0_32861-us"
+        },
+        "name": "Lurking Owl Kitten",
+        "id": 1922
+      },
+      "level": 1,
+      "quality": {
+        "type": "RARE",
+        "name": "Rare"
+      },
+      "stats": {
+        "breed_id": 18,
+        "health": 150,
+        "power": 12,
+        "speed": 12
+      },
+      "creature_display": {
+        "key": {
+          "href": "https://us.api.blizzard.com/data/wow/media/creature-display/71826?namespace=static-8.3.0_32861-us"
+        },
+        "id": 71826
+      },
+      "id": 147429168
+    }
+  ],
+  "unlocked_battle_pet_slots": 3
+}</value>
+  </data>
+  <data name="ProtectedCharacterProfileSummaryResponse" xml:space="preserve">
+    <value>{
+  "_links": {
+    "self": {
+      "href": "https://us.api.blizzard.com/profile/user/wow/protected-character/1262-107811065?namespace=profile-us"
+    },
+    "user": {
+      "href": "https://us.api.blizzard.com/profile/user"
+    },
+    "profile": {
+      "href": "https://us.api.blizzard.com/profile/user/wow?namespace=profile-us"
+    }
+  },
+  "id": 107811065,
+  "name": "Drinian",
+  "money": 1466691688,
+  "character": {
+    "key": {
+      "href": "https://us.api.blizzard.com/profile/wow/character/norgannon/drinian?namespace=profile-us"
+    },
+    "name": "Drinian",
+    "id": 107811065,
+    "realm": {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/realm/1262?namespace=dynamic-us"
+      },
+      "name": "Norgannon",
+      "id": 1262,
+      "slug": "norgannon"
+    }
+  },
+  "protected_stats": {
+    "total_number_deaths": 5475,
+    "total_gold_gained": 10579308330,
+    "total_gold_lost": 9149012174,
+    "total_item_value_gained": 3712943866,
+    "level_number_deaths": 242,
+    "level_gold_gained": 1721193990,
+    "level_gold_lost": 1410241805,
+    "level_item_value_gained": 767552800
+  },
+  "position": {
+    "zone": {
+      "name": "Tradewinds Market",
+      "id": 8718
+    },
+    "map": {
+      "name": "Kul Tiras",
+      "id": 1643
+    },
+    "x": 1158.7345,
+    "y": -594.15985,
+    "z": 28.691963,
+    "facing": 0.8178539
+  },
+  "bind_position": {
+    "zone": {
+      "name": "Snug Harbor Inn",
+      "id": 9801
+    },
+    "map": {
+      "name": "Kul Tiras",
+      "id": 1643
+    },
+    "x": 1184.1769,
+    "y": -593.08014,
+    "z": 31.502104,
+    "facing": 3.7450316
+  },
+  "wow_account": 19795845
+}</value>
+  </data>
 </root>


### PR DESCRIPTION
Added support for the Account Profile API.  Added an IAccountProfileApi interface to describe the capabilities of the API.  The IWarcraftClient interface implements this interface via the IProfileApi interface.  Refactored the internals of WarcraftClient to allow the access token to be passed as a parameter.