### PR TITLE
Updated PackageTags elements to use semicolons

### DIFF
--- a/src/ArgentPonyWarcraftClient.Extensions.DependencyInjection/ArgentPonyWarcraftClient.Extensions.DependencyInjection.csproj
+++ b/src/ArgentPonyWarcraftClient.Extensions.DependencyInjection/ArgentPonyWarcraftClient.Extensions.DependencyInjection.csproj
@@ -8,7 +8,7 @@
     <Copyright>Copyright © Dan Jagnow 2017</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Title>Argent Pony Warcraft Client</Title>
-    <PackageTags>Warcraft World-of-Warcraft WoW Blizzard Dependency-Injection DI</PackageTags>
+    <PackageTags>Warcraft;World-of-Warcraft;WoW;Blizzard;Dependency-Injection;DI</PackageTags>
     <PackageProjectUrl>https://github.com/blizzard-net/warcraft</PackageProjectUrl>
     <RepositoryUrl>https://github.com/blizzard-net/warcraft</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/src/ArgentPonyWarcraftClient/ArgentPonyWarcraftClient.csproj
+++ b/src/ArgentPonyWarcraftClient/ArgentPonyWarcraftClient.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -8,7 +8,7 @@
     <Copyright>Copyright © Dan Jagnow 2017</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Title>Argent Pony Warcraft Client</Title>
-    <PackageTags>Warcraft World-of-Warcraft WoW Blizzard</PackageTags>
+    <PackageTags>Warcraft;World-of-Warcraft;WoW;Blizzard</PackageTags>
     <PackageProjectUrl>https://github.com/blizzard-net/warcraft</PackageProjectUrl>
     <RepositoryUrl>https://github.com/blizzard-net/warcraft</RepositoryUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
Updated PackageTags elements to use semicolons instead of spaces as separators between tags, as documented at https://docs.microsoft.com/en-us/dotnet/core/tools/csproj#packagetags and noted in https://github.com/blizzard-net/warcraft/pull/143#discussion_r457662591.