### PR TITLE
Removed the region parameter from GetAsync

### DIFF
--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/AchievementApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/AchievementApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<AchievementCategoriesIndex>> GetAchievementCategoriesIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<AchievementCategoriesIndex>(region, $"{host}/data/wow/achievement-category/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<AchievementCategoriesIndex>($"{host}/data/wow/achievement-category/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<AchievementCategory>> GetAchievementCategoryAsync(int achievementCategoryId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<AchievementCategory>(region, $"{host}/data/wow/achievement-category/{achievementCategoryId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<AchievementCategory>($"{host}/data/wow/achievement-category/{achievementCategoryId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -40,7 +40,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<AchievementsIndex>> GetAchievementsIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<AchievementsIndex>(region, $"{host}/data/wow/achievement/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<AchievementsIndex>($"{host}/data/wow/achievement/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -53,7 +53,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<Achievement>> GetAchievementAsync(int achievementId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<Achievement>(region, $"{host}/data/wow/achievement/{achievementId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<Achievement>($"{host}/data/wow/achievement/{achievementId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -66,7 +66,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<AchievementMedia>> GetAchievementMediaAsync(int achievementId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<AchievementMedia>(region, $"{host}/data/wow/media/achievement/{achievementId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<AchievementMedia>($"{host}/data/wow/media/achievement/{achievementId}?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/AuctionHouseApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/AuctionHouseApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<AuctionsIndex>> GetAuctionsAsync(int connectedRealmId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<AuctionsIndex>(region, $"{host}/data/wow/connected-realm/{connectedRealmId}/auctions?namespace={@namespace}&locale={locale}");
+            return await GetAsync<AuctionsIndex>($"{host}/data/wow/connected-realm/{connectedRealmId}/auctions?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/AzeriteEssenceApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/AzeriteEssenceApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<AzeriteEssencesIndex>> GetAzeriteEssencesIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<AzeriteEssencesIndex>(region, $"{host}/data/wow/azerite-essence/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<AzeriteEssencesIndex>($"{host}/data/wow/azerite-essence/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<AzeriteEssence>> GetAzeriteEssenceAsync(int azeriteEssenceId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<AzeriteEssence>(region, $"{host}/data/wow/azerite-essence/{azeriteEssenceId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<AzeriteEssence>($"{host}/data/wow/azerite-essence/{azeriteEssenceId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -40,7 +40,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<AzeriteEssenceMedia>> GetAzeriteEssenceMediaAsync(int azeriteEssenceId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<AzeriteEssenceMedia>(region, $"{host}/data/wow/media/azerite-essence/{azeriteEssenceId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<AzeriteEssenceMedia>($"{host}/data/wow/media/azerite-essence/{azeriteEssenceId}?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/ConnectedRealmApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/ConnectedRealmApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<ConnectedRealmsIndex>> GetConnectedRealmsIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<ConnectedRealmsIndex>(region, $"{host}/data/wow/connected-realm/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<ConnectedRealmsIndex>($"{host}/data/wow/connected-realm/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<ConnectedRealm>> GetConnectedRealmAsync(int connectedRealmId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<ConnectedRealm>(region, $"{host}/data/wow/connected-realm/{connectedRealmId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<ConnectedRealm>($"{host}/data/wow/connected-realm/{connectedRealmId}?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/CreatureApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/CreatureApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CreatureFamiliesIndex>> GetCreatureFamiliesIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CreatureFamiliesIndex>(region, $"{host}/data/wow/creature-family/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CreatureFamiliesIndex>($"{host}/data/wow/creature-family/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CreatureFamily>> GetCreatureFamilyAsync(int creatureFamilyId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CreatureFamily>(region, $"{host}/data/wow/creature-family/{creatureFamilyId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CreatureFamily>($"{host}/data/wow/creature-family/{creatureFamilyId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -40,7 +40,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CreatureTypesIndex>> GetCreatureTypesIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CreatureTypesIndex>(region, $"{host}/data/wow/creature-type/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CreatureTypesIndex>($"{host}/data/wow/creature-type/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -53,7 +53,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CreatureType>> GetCreatureTypeAsync(int creatureTypeId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CreatureType>(region, $"{host}/data/wow/creature-type/{creatureTypeId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CreatureType>($"{host}/data/wow/creature-type/{creatureTypeId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -66,7 +66,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<Creature>> GetCreatureAsync(int creatureId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<Creature>(region, $"{host}/data/wow/creature/{creatureId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<Creature>($"{host}/data/wow/creature/{creatureId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -79,7 +79,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CreatureDisplayMedia>> GetCreatureDisplayMediaAsync(int creatureDisplayId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CreatureDisplayMedia>(region, $"{host}/data/wow/media/creature-display/{creatureDisplayId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CreatureDisplayMedia>($"{host}/data/wow/media/creature-display/{creatureDisplayId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -92,7 +92,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CreatureFamilyMedia>> GetCreatureFamilyMediaAsync(int creatureFamilyId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CreatureFamilyMedia>(region, $"{host}/data/wow/media/creature-family/{creatureFamilyId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CreatureFamilyMedia>($"{host}/data/wow/media/creature-family/{creatureFamilyId}?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/GuildCrestApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/GuildCrestApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<GuildCrestComponentsIndex>> GetGuildCrestComponentsIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<GuildCrestComponentsIndex>(region, $"{host}/data/wow/guild-crest/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<GuildCrestComponentsIndex>($"{host}/data/wow/guild-crest/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<GuildCrestBorderMedia>> GetGuildCrestBorderMediaAsync(int borderId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<GuildCrestBorderMedia>(region, $"{host}/data/wow/media/guild-crest/border/{borderId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<GuildCrestBorderMedia>($"{host}/data/wow/media/guild-crest/border/{borderId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -40,7 +40,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<GuildCrestEmblemMedia>> GetGuildCrestEmblemMediaAsync(int emblemId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<GuildCrestEmblemMedia>(region, $"{host}/data/wow/media/guild-crest/emblem/{emblemId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<GuildCrestEmblemMedia>($"{host}/data/wow/media/guild-crest/emblem/{emblemId}?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/ItemApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/ItemApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<ItemClassesIndex>> GetItemClassesIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<ItemClassesIndex>(region, $"{host}/data/wow/item-class/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<ItemClassesIndex>($"{host}/data/wow/item-class/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<ItemClass>> GetItemClassAsync(int itemClassId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<ItemClass>(region, $"{host}/data/wow/item-class/{itemClassId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<ItemClass>($"{host}/data/wow/item-class/{itemClassId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -40,7 +40,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<ItemSetsIndex>> GetItemSetsIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<ItemSetsIndex>(region, $"{host}/data/wow/item-set/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<ItemSetsIndex>($"{host}/data/wow/item-set/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -53,7 +53,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<ItemSet>> GetItemSetAsync(int itemSetId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<ItemSet>(region, $"{host}/data/wow/item-set/{itemSetId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<ItemSet>($"{host}/data/wow/item-set/{itemSetId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -66,7 +66,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<ItemSubclass>> GetItemSubclassAsync(int itemClassId, int itemSubclassId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<ItemSubclass>(region, $"{host}/data/wow/item-class/{itemClassId}/item-subclass/{itemSubclassId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<ItemSubclass>($"{host}/data/wow/item-class/{itemClassId}/item-subclass/{itemSubclassId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -79,7 +79,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<Item>> GetItemAsync(int itemId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<Item>(region, $"{host}/data/wow/item/{itemId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<Item>($"{host}/data/wow/item/{itemId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -92,7 +92,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<ItemMedia>> GetItemMediaAsync(int itemId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<ItemMedia>(region, $"{host}/data/wow/media/item/{itemId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<ItemMedia>($"{host}/data/wow/media/item/{itemId}?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/JournalApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/JournalApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<JournalExpansionsIndex>> GetJournalExpansionsIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<JournalExpansionsIndex>(region, $"{host}/data/wow/journal-expansion/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<JournalExpansionsIndex>($"{host}/data/wow/journal-expansion/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<JournalExpansion>> GetJournalExpansionAsync(int journalExpansionId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<JournalExpansion>(region, $"{host}/data/wow/journal-expansion/{journalExpansionId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<JournalExpansion>($"{host}/data/wow/journal-expansion/{journalExpansionId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -40,7 +40,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<JournalEncountersIndex>> GetJournalEncountersIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<JournalEncountersIndex>(region, $"{host}/data/wow/journal-encounter/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<JournalEncountersIndex>($"{host}/data/wow/journal-encounter/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -53,7 +53,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<Encounter>> GetJournalEncounterAsync(int journalEncounterId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<Encounter>(region, $"{host}/data/wow/journal-encounter/{journalEncounterId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<Encounter>($"{host}/data/wow/journal-encounter/{journalEncounterId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -66,7 +66,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<JournalInstancesIndex>> GetJournalInstancesIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<JournalInstancesIndex>(region, $"{host}/data/wow/journal-instance/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<JournalInstancesIndex>($"{host}/data/wow/journal-instance/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -79,7 +79,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<Instance>> GetJournalInstanceAsync(int journalInstanceId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<Instance>(region, $"{host}/data/wow/journal-instance/{journalInstanceId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<Instance>($"{host}/data/wow/journal-instance/{journalInstanceId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -92,7 +92,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<JournalInstanceMedia>> GetJournalInstanceMediaAsync(int journalInstanceId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<JournalInstanceMedia>(region, $"{host}/data/wow/media/journal-instance/{journalInstanceId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<JournalInstanceMedia>($"{host}/data/wow/media/journal-instance/{journalInstanceId}?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/MountApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/MountApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<MountsIndex>> GetMountsIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<MountsIndex>(region, $"{host}/data/wow/mount/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<MountsIndex>($"{host}/data/wow/mount/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<Mount>> GetMountAsync(int mountId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<Mount>(region, $"{host}/data/wow/mount/{mountId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<Mount>($"{host}/data/wow/mount/{mountId}?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/MythicKeystoneAffixApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/MythicKeystoneAffixApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<MythicKeystoneAffixesIndex>> GetMythicKeystoneAffixesIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<MythicKeystoneAffixesIndex>(region, $"{host}/data/wow/keystone-affix/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<MythicKeystoneAffixesIndex>($"{host}/data/wow/keystone-affix/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<MythicKeystoneAffix>> GetMythicKeystoneAffixAsync(int keystoneAffixId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<MythicKeystoneAffix>(region, $"{host}/data/wow/keystone-affix/{keystoneAffixId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<MythicKeystoneAffix>($"{host}/data/wow/keystone-affix/{keystoneAffixId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -40,7 +40,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<MythicKeystoneAffixMedia>> GetMythicKeystoneAffixMediaAsync(int keystoneAffixId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<MythicKeystoneAffixMedia>(region, $"{host}/data/wow/media/keystone-affix/{keystoneAffixId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<MythicKeystoneAffixMedia>($"{host}/data/wow/media/keystone-affix/{keystoneAffixId}?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/MythicKeystoneDungeonApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/MythicKeystoneDungeonApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<MythicKeystoneDungeonsIndex>> GetMythicKeystoneDungeonsIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<MythicKeystoneDungeonsIndex>(region, $"{host}/data/wow/mythic-keystone/dungeon/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<MythicKeystoneDungeonsIndex>($"{host}/data/wow/mythic-keystone/dungeon/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<MythicKeystoneDungeon>> GetMythicKeystoneDungeonAsync(int dungeonId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<MythicKeystoneDungeon>(region, $"{host}/data/wow/mythic-keystone/dungeon/{dungeonId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<MythicKeystoneDungeon>($"{host}/data/wow/mythic-keystone/dungeon/{dungeonId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -40,7 +40,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<MythicKeystoneIndex>> GetMythicKeystoneIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<MythicKeystoneIndex>(region, $"{host}/data/wow/mythic-keystone/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<MythicKeystoneIndex>($"{host}/data/wow/mythic-keystone/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -53,7 +53,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<MythicKeystonePeriodsIndex>> GetMythicKeystonePeriodsIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<MythicKeystonePeriodsIndex>(region, $"{host}/data/wow/mythic-keystone/period/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<MythicKeystonePeriodsIndex>($"{host}/data/wow/mythic-keystone/period/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -66,7 +66,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<MythicKeystonePeriod>> GetMythicKeystonePeriodAsync(int periodId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<MythicKeystonePeriod>(region, $"{host}/data/wow/mythic-keystone/period/{periodId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<MythicKeystonePeriod>($"{host}/data/wow/mythic-keystone/period/{periodId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -79,7 +79,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<MythicKeystoneSeasonsIndex>> GetMythicKeystoneSeasonsIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<MythicKeystoneSeasonsIndex>(region, $"{host}/data/wow/mythic-keystone/season/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<MythicKeystoneSeasonsIndex>($"{host}/data/wow/mythic-keystone/season/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -92,7 +92,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<MythicKeystoneSeason>> GetMythicKeystoneSeasonAsync(int seasonId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<MythicKeystoneSeason>(region, $"{host}/data/wow/mythic-keystone/season/{seasonId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<MythicKeystoneSeason>($"{host}/data/wow/mythic-keystone/season/{seasonId}?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/MythicKeystoneLeaderboardApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/MythicKeystoneLeaderboardApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<MythicKeystoneLeaderboardsIndex>> GetMythicKeystoneLeaderboardsIndexAsync(int connectedRealmId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<MythicKeystoneLeaderboardsIndex>(region, $"{host}/data/wow/connected-realm/{connectedRealmId}/mythic-leaderboard/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<MythicKeystoneLeaderboardsIndex>($"{host}/data/wow/connected-realm/{connectedRealmId}/mythic-leaderboard/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<MythicKeystoneLeaderboard>> GetMythicKeystoneLeaderboard(int connectedRealmId, int dungeonId, int period, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<MythicKeystoneLeaderboard>(region, $"{host}/data/wow/connected-realm/{connectedRealmId}/mythic-leaderboard/{dungeonId}/period/{period}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<MythicKeystoneLeaderboard>($"{host}/data/wow/connected-realm/{connectedRealmId}/mythic-leaderboard/{dungeonId}/period/{period}?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/MythicRaidLeaderboardApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/MythicRaidLeaderboardApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<MythicRaidLeaderboard>> GetMythicRaidLeaderboardAsync(string raid, string faction, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<MythicRaidLeaderboard>(region, $"{host}/data/wow/leaderboard/hall-of-fame/{raid}/{faction}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<MythicRaidLeaderboard>($"{host}/data/wow/leaderboard/hall-of-fame/{raid}/{faction}?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/PetApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/PetApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PetsIndex>> GetPetsIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<PetsIndex>(region, $"{host}/data/wow/pet/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<PetsIndex>($"{host}/data/wow/pet/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<Pet>> GetPetAsync(int petId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<Pet>(region, $"{host}/data/wow/pet/{petId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<Pet>($"{host}/data/wow/pet/{petId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -40,7 +40,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PetAbilitiesIndex>> GetPetAbilitiesIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<PetAbilitiesIndex>(region, $"{host}/data/wow/pet-ability/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<PetAbilitiesIndex>($"{host}/data/wow/pet-ability/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -53,7 +53,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PetAbility>> GetPetAbilityAsync(int petAbilityId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<PetAbility>(region, $"{host}/data/wow/pet-ability/{petAbilityId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<PetAbility>($"{host}/data/wow/pet-ability/{petAbilityId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -66,7 +66,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PetAbilityMedia>> GetPetAbilityMediaAsync(int petAbilityId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<PetAbilityMedia>(region, $"{host}/data/wow/media/pet-ability/{petAbilityId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<PetAbilityMedia>($"{host}/data/wow/media/pet-ability/{petAbilityId}?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/PlayableClassApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/PlayableClassApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PlayableClassesIndex>> GetPlayableClassesIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<PlayableClassesIndex>(region, $"{host}/data/wow/playable-class/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<PlayableClassesIndex>($"{host}/data/wow/playable-class/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PlayableClass>> GetPlayableClassAsync(int classId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<PlayableClass>(region, $"{host}/data/wow/playable-class/{classId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<PlayableClass>($"{host}/data/wow/playable-class/{classId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -40,7 +40,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PlayableClassMedia>> GetPlayableClassMediaAsync(int classId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<PlayableClassMedia>(region, $"{host}/data/wow/media/playable-class/{classId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<PlayableClassMedia>($"{host}/data/wow/media/playable-class/{classId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -53,7 +53,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PvpTalentSlots>> GetPvpTalentSlotsAsync(int classId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<PvpTalentSlots>(region, $"{host}/data/wow/playable-class/{classId}/pvp-talent-slots?namespace={@namespace}&locale={locale}");
+            return await GetAsync<PvpTalentSlots>($"{host}/data/wow/playable-class/{classId}/pvp-talent-slots?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/PlayableRaceApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/PlayableRaceApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PlayableRacesIndex>> GetPlayableRacesIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<PlayableRacesIndex>(region, $"{host}/data/wow/playable-race/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<PlayableRacesIndex>($"{host}/data/wow/playable-race/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PlayableRace>> GetPlayableRaceAsync(int playableRaceId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<PlayableRace>(region, $"{host}/data/wow/playable-race/{playableRaceId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<PlayableRace>($"{host}/data/wow/playable-race/{playableRaceId}?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/PlayableSpecializationApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/PlayableSpecializationApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PlayableSpecializationsIndex>> GetPlayableSpecializationsIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<PlayableSpecializationsIndex>(region, $"{host}/data/wow/playable-specialization/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<PlayableSpecializationsIndex>($"{host}/data/wow/playable-specialization/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PlayableSpecialization>> GetPlayableSpecializationAsync(int specId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<PlayableSpecialization>(region, $"{host}/data/wow/playable-specialization/{specId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<PlayableSpecialization>($"{host}/data/wow/playable-specialization/{specId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -40,7 +40,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PlayableSpecializationMedia>> GetPlayableSpecializationMediaAsync(int specId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<PlayableSpecializationMedia>(region, $"{host}/data/wow/media/playable-specialization/{specId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<PlayableSpecializationMedia>($"{host}/data/wow/media/playable-specialization/{specId}?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/PowerTypeApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/PowerTypeApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PowerTypesIndex>> GetPowerTypesIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<PowerTypesIndex>(region, $"{host}/data/wow/power-type/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<PowerTypesIndex>($"{host}/data/wow/power-type/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PowerType>> GetPowerTypeAsync(int powerTypeId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<PowerType>(region, $"{host}/data/wow/power-type/{powerTypeId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<PowerType>($"{host}/data/wow/power-type/{powerTypeId}?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/ProfessionApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/ProfessionApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<ProfessionsIndex>> GetProfessionsIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<ProfessionsIndex>(region, $"{host}/data/wow/profession/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<ProfessionsIndex>($"{host}/data/wow/profession/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<Profession>> GetProfessionAsync(int professionId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<Profession>(region, $"{host}/data/wow/profession/{professionId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<Profession>($"{host}/data/wow/profession/{professionId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -40,7 +40,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<ProfessionMedia>> GetProfessionMediaAsync(int professionId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<ProfessionMedia>(region, $"{host}/data/wow/media/profession/{professionId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<ProfessionMedia>($"{host}/data/wow/media/profession/{professionId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -53,7 +53,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<SkillTier>> GetSkillTierAsync(int professionId, int skillTierId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<SkillTier>(region, $"{host}/data/wow/profession/{professionId}/skill-tier/{skillTierId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<SkillTier>($"{host}/data/wow/profession/{professionId}/skill-tier/{skillTierId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -66,7 +66,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<Recipe>> GetRecipeAsync(int recipeId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<Recipe>(region, $"{host}/data/wow/recipe/{recipeId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<Recipe>($"{host}/data/wow/recipe/{recipeId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -79,7 +79,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<RecipeMedia>> GetRecipeMediaAsync(int recipeId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<RecipeMedia>(region, $"{host}/data/wow/media/recipe/{recipeId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<RecipeMedia>($"{host}/data/wow/media/recipe/{recipeId}?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/PvpSeasonApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/PvpSeasonApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PvpSeasonsIndex>> GetPvpSeasonsIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<PvpSeasonsIndex>(region, $"{host}/data/wow/pvp-season/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<PvpSeasonsIndex>($"{host}/data/wow/pvp-season/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PvpSeason>> GetPvpSeasonAsync(int pvpSeasonId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<PvpSeason>(region, $"{host}/data/wow/pvp-season/{pvpSeasonId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<PvpSeason>($"{host}/data/wow/pvp-season/{pvpSeasonId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -40,7 +40,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PvpLeaderboardsIndex>> GetPvpLeaderboardsIndexAsync(int pvpSeasonId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<PvpLeaderboardsIndex>(region, $"{host}/data/wow/pvp-season/{pvpSeasonId}/pvp-leaderboard/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<PvpLeaderboardsIndex>($"{host}/data/wow/pvp-season/{pvpSeasonId}/pvp-leaderboard/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -53,7 +53,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PvpLeaderboard>> GetPvpLeaderboardAsync(int pvpSeasonId, string pvpBracket, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<PvpLeaderboard>(region, $"{host}/data/wow/pvp-season/{pvpSeasonId}/pvp-leaderboard/{pvpBracket}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<PvpLeaderboard>($"{host}/data/wow/pvp-season/{pvpSeasonId}/pvp-leaderboard/{pvpBracket}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -66,7 +66,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PvpRewardsIndex>> GetPvpRewardsIndexAsync(int pvpSeasonId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<PvpRewardsIndex>(region, $"{host}/data/wow/pvp-season/{pvpSeasonId}/pvp-reward/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<PvpRewardsIndex>($"{host}/data/wow/pvp-season/{pvpSeasonId}/pvp-reward/index?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/PvpTierApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/PvpTierApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PvpTiersIndex>> GetPvpTiersIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<PvpTiersIndex>(region, $"{host}/data/wow/pvp-tier/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<PvpTiersIndex>($"{host}/data/wow/pvp-tier/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PvpTier>> GetPvpTierAsync(int pvpTierId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<PvpTier>(region, $"{host}/data/wow/pvp-tier/{pvpTierId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<PvpTier>($"{host}/data/wow/pvp-tier/{pvpTierId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -40,7 +40,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PvpTierMedia>> GetPvpTierMediaAsync(int pvpTierId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<PvpTierMedia>(region, $"{host}/data/wow/media/pvp-tier/{pvpTierId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<PvpTierMedia>($"{host}/data/wow/media/pvp-tier/{pvpTierId}?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/QuestApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/QuestApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<QuestsIndex>> GetQuestsIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<QuestsIndex>(region, $"{host}/data/wow/quest/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<QuestsIndex>($"{host}/data/wow/quest/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<Quest>> GetQuestAsync(int questId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<Quest>(region, $"{host}/data/wow/quest/{questId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<Quest>($"{host}/data/wow/quest/{questId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -40,7 +40,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<QuestCategoriesIndex>> GetQuestCategoriesIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<QuestCategoriesIndex>(region, $"{host}/data/wow/quest/category/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<QuestCategoriesIndex>($"{host}/data/wow/quest/category/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -53,7 +53,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<QuestCategory>> GetQuestCategoryAsync(int questCategoryId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<QuestCategory>(region, $"{host}/data/wow/quest/category/{questCategoryId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<QuestCategory>($"{host}/data/wow/quest/category/{questCategoryId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -66,7 +66,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<QuestAreasIndex>> GetQuestAreasIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<QuestAreasIndex>(region, $"{host}/data/wow/quest/area/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<QuestAreasIndex>($"{host}/data/wow/quest/area/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -79,7 +79,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<QuestArea>> GetQuestAreaAsync(int questAreaId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<QuestArea>(region, $"{host}/data/wow/quest/area/{questAreaId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<QuestArea>($"{host}/data/wow/quest/area/{questAreaId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -92,7 +92,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<QuestTypesIndex>> GetQuestTypesIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<QuestTypesIndex>(region, $"{host}/data/wow/quest/type/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<QuestTypesIndex>($"{host}/data/wow/quest/type/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -105,7 +105,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<QuestType>> GetQuestTypeAsync(int questTypeId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<QuestType>(region, $"{host}/data/wow/quest/type/{questTypeId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<QuestType>($"{host}/data/wow/quest/type/{questTypeId}?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/RealmApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/RealmApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<RealmsIndex>> GetRealmsIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<RealmsIndex>(region, $"{host}/data/wow/realm/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<RealmsIndex>($"{host}/data/wow/realm/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<Realm>> GetRealmAsync(string realmSlug, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<Realm>(region, $"{host}/data/wow/realm/{realmSlug}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<Realm>($"{host}/data/wow/realm/{realmSlug}?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/RegionApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/RegionApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<RegionsIndex>> GetRegionsIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<RegionsIndex>(region, $"{host}/data/wow/region/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<RegionsIndex>($"{host}/data/wow/region/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<RegionData>> GetRegionAsync(int regionId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<RegionData>(region, $"{host}/data/wow/region/{regionId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<RegionData>($"{host}/data/wow/region/{regionId}?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/ReputationsApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/ReputationsApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<ReputationFactionsIndex>> GetReputationFactionsIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<ReputationFactionsIndex>(region, $"{host}/data/wow/reputation-faction/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<ReputationFactionsIndex>($"{host}/data/wow/reputation-faction/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<ReputationFaction>> GetReputationFactionAsync(int reputationFactionId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<ReputationFaction>(region, $"{host}/data/wow/reputation-faction/{reputationFactionId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<ReputationFaction>($"{host}/data/wow/reputation-faction/{reputationFactionId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -40,7 +40,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<ReputationTiersIndex>> GetReputationTiersIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<ReputationTiersIndex>(region, $"{host}/data/wow/reputation-tiers/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<ReputationTiersIndex>($"{host}/data/wow/reputation-tiers/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -53,7 +53,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<ReputationTiers>> GetReputationTiersAsync(int reputationTiersId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<ReputationTiers>(region, $"{host}/data/wow/reputation-tiers/{reputationTiersId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<ReputationTiers>($"{host}/data/wow/reputation-tiers/{reputationTiersId}?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/SpellApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/SpellApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<Spell>> GetSpellAsync(int spellId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<Spell>(region, $"{host}/data/wow/spell/{spellId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<Spell>($"{host}/data/wow/spell/{spellId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<SpellMedia>> GetSpellMediaAsync(int spellId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<SpellMedia>(region, $"{host}/data/wow/media/spell/{spellId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<SpellMedia>($"{host}/data/wow/media/spell/{spellId}?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/TalentApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/TalentApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<TalentsIndex>> GetTalentsIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<TalentsIndex>(region, $"{host}/data/wow/talent/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<TalentsIndex>($"{host}/data/wow/talent/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<Talent>> GetTalentAsync(int talentId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<Talent>(region, $"{host}/data/wow/talent/{talentId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<Talent>($"{host}/data/wow/talent/{talentId}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -40,7 +40,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PvpTalentsIndex>> GetPvpTalentsIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<PvpTalentsIndex>(region, $"{host}/data/wow/pvp-talent/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<PvpTalentsIndex>($"{host}/data/wow/pvp-talent/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -53,7 +53,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PvpTalent>> GetPvpTalentAsync(int pvpTalentId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<PvpTalent>(region, $"{host}/data/wow/pvp-talent/{pvpTalentId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<PvpTalent>($"{host}/data/wow/pvp-talent/{pvpTalentId}?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/TitleApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/TitleApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<TitlesIndex>> GetTitlesIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<TitlesIndex>(region, $"{host}/data/wow/title/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<TitlesIndex>($"{host}/data/wow/title/index?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<Title>> GetTitleAsync(int titleId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<Title>(region, $"{host}/data/wow/title/{titleId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<Title>($"{host}/data/wow/title/{titleId}?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/WowTokenApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/WowTokenApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<WowTokenIndex>> GetWowTokenIndexAsync(string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<WowTokenIndex>(region, $"{host}/data/wow/token/index?namespace={@namespace}&locale={locale}");
+            return await GetAsync<WowTokenIndex>($"{host}/data/wow/token/index?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterAchievements.cs
+++ b/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterAchievements.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CharacterAchievementsSummary>> GetCharacterAchievementsSummaryAsync(string realmSlug, string characterName, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CharacterAchievementsSummary>(region, $"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/achievements?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CharacterAchievementsSummary>($"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/achievements?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CharacterAchievementStatistics>> GetCharacterAchievementStatisticsAsync(string realmSlug, string characterName, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CharacterAchievementStatistics>(region, $"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/achievements/statistics?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CharacterAchievementStatistics>($"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/achievements/statistics?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterAppearanceApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterAppearanceApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CharacterAppearanceSummary>> GetCharacterAppearanceSummaryAsync(string realmSlug, string characterName, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CharacterAppearanceSummary>(region, $"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/appearance?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CharacterAppearanceSummary>($"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/appearance?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterCollectionsApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterCollectionsApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CharacterCollectionsIndex>> GetCharacterCollectionsIndexAsync(string realmSlug, string characterName, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CharacterCollectionsIndex>(region, $"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/collections?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CharacterCollectionsIndex>($"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/collections?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CharacterPetsCollectionSummary>> GetCharacterPetsCollectionSummaryAsync(string realmSlug, string characterName, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CharacterPetsCollectionSummary>(region, $"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/collections/pets?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CharacterPetsCollectionSummary>($"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/collections/pets?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -40,7 +40,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CharacterMountsCollectionSummary>> GetCharacterMountsCollectionSummaryAsync(string realmSlug, string characterName, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CharacterMountsCollectionSummary>(region, $"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/collections/mounts?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CharacterMountsCollectionSummary>($"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/collections/mounts?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterEncountersApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterEncountersApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CharacterEncountersSummary>> GetCharacterEncountersSummaryAsync(string realmSlug, string characterName, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CharacterEncountersSummary>(region, $"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/encounters?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CharacterEncountersSummary>($"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/encounters?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CharacterDungeons>> GetCharacterDungeonsAsync(string realmSlug, string characterName, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CharacterDungeons>(region, $"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/encounters/dungeons?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CharacterDungeons>($"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/encounters/dungeons?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -40,7 +40,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CharacterRaids>> GetCharacterRaidsAsync(string realmSlug, string characterName, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CharacterRaids>(region, $"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/encounters/raids?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CharacterRaids>($"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/encounters/raids?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterEquipmentApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterEquipmentApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CharacterEquipmentSummary>> GetCharacterEquipmentSummaryAsync(string realmSlug, string characterName, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CharacterEquipmentSummary>(region, $"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/equipment?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CharacterEquipmentSummary>($"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/equipment?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterHunterPetsApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterHunterPetsApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CharacterHunterPetsSummary>> GetCharacterHunterPetsSummaryAsync(string realmSlug, string characterName, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CharacterHunterPetsSummary>(region, $"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/hunter-pets?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CharacterHunterPetsSummary>($"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/hunter-pets?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterMythicKeystoneProfileApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterMythicKeystoneProfileApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CharacterMythicKeystoneProfileIndex>> GetCharacterMythicKeystoneProfileIndexAsync(string realmSlug, string characterName, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CharacterMythicKeystoneProfileIndex>(region, $"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/mythic-keystone-profile?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CharacterMythicKeystoneProfileIndex>($"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/mythic-keystone-profile?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CharacterMythicKeystoneSeasonDetails>> GetCharacterMythicKeystoneSeasonDetailsAsync(string realmSlug, string characterName, int seasonId, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CharacterMythicKeystoneSeasonDetails>(region, $"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/mythic-keystone-profile/season/{seasonId}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CharacterMythicKeystoneSeasonDetails>($"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/mythic-keystone-profile/season/{seasonId}?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterProfessionsApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterProfessionsApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CharacterProfessionsSummary>> GetCharacterProfessionsSummaryAsync(string realmSlug, string characterName, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CharacterProfessionsSummary>(region, $"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/professions?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CharacterProfessionsSummary>($"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/professions?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterProfileApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterProfileApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CharacterProfileSummary>> GetCharacterProfileSummaryAsync(string realmSlug, string characterName, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CharacterProfileSummary>(region, $"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CharacterProfileSummary>($"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CharacterStatus>> GetCharacterStatusAsync(string realmSlug, string characterName, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CharacterStatus>(region, $"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/status?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CharacterStatus>($"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/status?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterPvpApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterPvpApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CharacterPvpBracketStatistics>> GetCharacterPvpBracketStatisticsAsync(string realmSlug, string characterName, string pvpBracket, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CharacterPvpBracketStatistics>(region, $"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/pvp-bracket/{pvpBracket}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CharacterPvpBracketStatistics>($"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/pvp-bracket/{pvpBracket}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CharacterPvpSummary>> GetCharacterPvpSummaryAsync(string realmSlug, string characterName, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CharacterPvpSummary>(region, $"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/pvp-summary?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CharacterPvpSummary>($"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/pvp-summary?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterQuestsApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterQuestsApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CharacterQuests>> GetCharacterQuestsAsync(string realmSlug, string characterName, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CharacterQuests>(region, $"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/quests?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CharacterQuests>($"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/quests?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CharacterCompletedQuests>> GetCharacterCompletedQuestsAsync(string realmSlug, string characterName, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CharacterCompletedQuests>(region, $"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/quests/completed?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CharacterCompletedQuests>($"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/quests/completed?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterReputationsApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterReputationsApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CharacterReputationsSummary>> GetCharacterReputationsSummaryAsync(string realmSlug, string characterName, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CharacterReputationsSummary>(region, $"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/reputations?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CharacterReputationsSummary>($"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/reputations?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterSpecializationsApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterSpecializationsApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CharacterSpecializationsSummary>> GetCharacterSpecializationsSummaryAsync(string realmSlug, string characterName, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CharacterSpecializationsSummary>(region, $"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/specializations?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CharacterSpecializationsSummary>($"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/specializations?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterStatisticsApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterStatisticsApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CharacterStatisticsSummary>> GetCharacterStatisticsSummaryAsync(string realmSlug, string characterName, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CharacterStatisticsSummary>(region, $"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/statistics?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CharacterStatisticsSummary>($"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/statistics?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterTitlesApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/ProfileApi/CharacterTitlesApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<CharacterTitlesSummary>> GetCharacterTitlesSummaryAsync(string realmSlug, string characterName, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<CharacterTitlesSummary>(region, $"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/titles?namespace={@namespace}&locale={locale}");
+            return await GetAsync<CharacterTitlesSummary>($"{host}/profile/wow/character/{realmSlug}/{characterName?.ToLowerInvariant()}/titles?namespace={@namespace}&locale={locale}");
         }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Client/ProfileApi/GuildApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/ProfileApi/GuildApi.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<Guild>> GetGuildAsync(string realmSlug, string nameSlug, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<Guild>(region, $"{host}/data/wow/guild/{realmSlug}/{nameSlug?.ToLowerInvariant()}?namespace={@namespace}&locale={locale}");
+            return await GetAsync<Guild>($"{host}/data/wow/guild/{realmSlug}/{nameSlug?.ToLowerInvariant()}?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<GuildActivity>> GetGuildActivityAsync(string realmSlug, string nameSlug, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<GuildActivity>(region, $"{host}/data/wow/guild/{realmSlug}/{nameSlug?.ToLowerInvariant()}/activity?namespace={@namespace}&locale={locale}");
+            return await GetAsync<GuildActivity>($"{host}/data/wow/guild/{realmSlug}/{nameSlug?.ToLowerInvariant()}/activity?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -40,7 +40,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<GuildAchievements>> GetGuildAchievementsAsync(string realmSlug, string nameSlug, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<GuildAchievements>(region, $"{host}/data/wow/guild/{realmSlug}/{nameSlug?.ToLowerInvariant()}/achievements?namespace={@namespace}&locale={locale}");
+            return await GetAsync<GuildAchievements>($"{host}/data/wow/guild/{realmSlug}/{nameSlug?.ToLowerInvariant()}/achievements?namespace={@namespace}&locale={locale}");
         }
 
         /// <inheritdoc />
@@ -53,7 +53,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<GuildRoster>> GetGuildRosterAsync(string realmSlug, string nameSlug, string @namespace, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await GetAsync<GuildRoster>(region, $"{host}/data/wow/guild/{realmSlug}/{nameSlug?.ToLowerInvariant()}/roster?namespace={@namespace}&locale={locale}");
+            return await GetAsync<GuildRoster>($"{host}/data/wow/guild/{realmSlug}/{nameSlug?.ToLowerInvariant()}/roster?namespace={@namespace}&locale={locale}");
         }
     }
 }


### PR DESCRIPTION
Removed the region parameter from a GetAsync method overload in WarcraftClient.  Added a GetRegionFromUri method that determines the region by parsing the URI instead.  This is only needed to renew an OAuth token when it is about to expire, so it should seldom be called.