### PR TITLE
Changed private setters to public in model classes

### DIFF
--- a/src/ArgentPonyWarcraftClient/Models/Asset.cs
+++ b/src/ArgentPonyWarcraftClient/Models/Asset.cs
@@ -12,12 +12,12 @@ namespace ArgentPonyWarcraftClient
         /// Gets the key of the asset.
         /// </summary>
         [JsonPropertyName("key")]
-        public string Key { get; private set; }
+        public string Key { get; set; }
 
         /// <summary>
         /// Gets a URI for retrieving the asset value.
         /// </summary>
         [JsonPropertyName("value")]
-        public Uri Value { get; private set; }
+        public Uri Value { get; set; }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Achievement/Achievement.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Achievement/Achievement.cs
@@ -11,66 +11,66 @@ namespace ArgentPonyWarcraftClient
         /// Gets links for this achievement.
         /// </summary>
         [JsonPropertyName("_links")]
-        public Links Links { get; private set; }
+        public Links Links { get; set; }
 
         /// <summary>
         /// Gets the ID of this achievement.
         /// </summary>
         [JsonPropertyName("id")]
-        public int Id { get; private set; }
+        public int Id { get; set; }
 
         /// <summary>
         /// Gets a reference to the achievement category to which this achievement belongs.
         /// </summary>
         [JsonPropertyName("category")]
-        public AchievementCategoryReference Category { get; private set; }
+        public AchievementCategoryReference Category { get; set; }
 
         /// <summary>
         /// Gets the name of this achievement.
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get; private set; }
+        public string Name { get; set; }
 
         /// <summary>
         /// Gets the description of this achievement.
         /// </summary>
         [JsonPropertyName("description")]
-        public string Description { get; private set; }
+        public string Description { get; set; }
 
         /// <summary>
         /// Gets the number of achievement points associated with this achievement.
         /// </summary>
         [JsonPropertyName("points")]
-        public int Points { get; private set; }
+        public int Points { get; set; }
 
         /// <summary>
         /// Gets a value indicating whether this achievement is account-wide.
         /// </summary>
         [JsonPropertyName("is_account_wide")]
-        public bool IsAccountWide { get; private set; }
+        public bool IsAccountWide { get; set; }
 
         /// <summary>
         /// Gets the criteria for this achievement.
         /// </summary>
         [JsonPropertyName("criteria")]
-        public AchievementCriteria Criteria { get; private set; }
+        public AchievementCriteria Criteria { get; set; }
 
         /// <summary>
         /// Gets a reference to the next achievement.
         /// </summary>
         [JsonPropertyName("next_achievement")]
-        public AchievementReference NextAchievement { get; private set; }
+        public AchievementReference NextAchievement { get; set; }
 
         /// <summary>
         /// Gets the media associated with this achievement.
         /// </summary>
         [JsonPropertyName("media")]
-        public Media Media { get; private set; }
+        public Media Media { get; set; }
 
         /// <summary>
         /// Gets the display order.
         /// </summary>
         [JsonPropertyName("display_order")]
-        public int DisplayOrder { get; private set; }
+        public int DisplayOrder { get; set; }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Achievement/AchievementCategoriesIndex.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Achievement/AchievementCategoriesIndex.cs
@@ -11,24 +11,24 @@ namespace ArgentPonyWarcraftClient
         /// Gets links for the index of achievement categories.
         /// </summary>
         [JsonPropertyName("_links")]
-        public Links Links { get; private set; }
+        public Links Links { get; set; }
 
         /// <summary>
         /// Gets references to achievement categories.
         /// </summary>
         [JsonPropertyName("categories")]
-        public AchievementCategoryReference[] Categories { get; private set; }
+        public AchievementCategoryReference[] Categories { get; set; }
 
         /// <summary>
         /// Gets references to root achievement categories.
         /// </summary>
         [JsonPropertyName("root_categories")]
-        public AchievementCategoryReference[] RootCategories { get; private set; }
+        public AchievementCategoryReference[] RootCategories { get; set; }
 
         /// <summary>
         /// Gets references to guild achievement categories.
         /// </summary>
         [JsonPropertyName("guild_categories")]
-        public AchievementCategoryReference[] GuildCategories { get; private set; }
+        public AchievementCategoryReference[] GuildCategories { get; set; }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Achievement/AchievementCategory.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Achievement/AchievementCategory.cs
@@ -11,48 +11,48 @@ namespace ArgentPonyWarcraftClient
         /// Gets links for this achievement category.
         /// </summary>
         [JsonPropertyName("_links")]
-        public Links Links { get; private set; }
+        public Links Links { get; set; }
 
         /// <summary>
         /// Gets the ID of this achievement category.
         /// </summary>
         [JsonPropertyName("id")]
-        public int Id { get; private set; }
+        public int Id { get; set; }
 
         /// <summary>
         /// Gets the name of this achievement category.
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get; private set; }
+        public string Name { get; set; }
 
         /// <summary>
         /// Gets references to the achievements in this category.
         /// </summary>
         [JsonPropertyName("achievements")]
-        public AchievementReference[] Achievements { get; private set; }
+        public AchievementReference[] Achievements { get; set; }
 
         /// <summary>
         /// Gets references to subcategories of this achievement category.
         /// </summary>
         [JsonPropertyName("subcategories")]
-        public AchievementCategoryReference[] Subcategories { get; private set; }
+        public AchievementCategoryReference[] Subcategories { get; set; }
 
         /// <summary>
         /// Gets a value that indicates whether this is a guild category.
         /// </summary>
         [JsonPropertyName("is_guild_category")]
-        public bool IsGuildCategory { get; private set; }
+        public bool IsGuildCategory { get; set; }
 
         /// <summary>
         /// Gets the aggregates by faction.
         /// </summary>
         [JsonPropertyName("aggregates_by_faction")]
-        public AggregatesByFaction AggregatesByFaction { get; private set; }
+        public AggregatesByFaction AggregatesByFaction { get; set; }
 
         /// <summary>
         /// Gets the display order.
         /// </summary>
         [JsonPropertyName("display_order")]
-        public int DisplayOrder { get; private set; }
+        public int DisplayOrder { get; set; }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Achievement/AchievementCategoryReference.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Achievement/AchievementCategoryReference.cs
@@ -11,18 +11,18 @@ namespace ArgentPonyWarcraftClient
         /// Gets the key for this achievement category.
         /// </summary>
         [JsonPropertyName("key")]
-        public Self Key { get; private set; }
+        public Self Key { get; set; }
 
         /// <summary>
         /// Gets the name of this achievement category.
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get; private set; }
+        public string Name { get; set; }
 
         /// <summary>
         /// Gets the ID of this achievement category.
         /// </summary>
         [JsonPropertyName("id")]
-        public int Id { get; private set; }
+        public int Id { get; set; }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Achievement/AchievementCriteria.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Achievement/AchievementCriteria.cs
@@ -11,18 +11,18 @@ namespace ArgentPonyWarcraftClient
         /// Gets the ID of the criteria.
         /// </summary>
         [JsonPropertyName("id")]
-        public int Id { get; private set; }
+        public int Id { get; set; }
 
         /// <summary>
         /// Gets the description of the criteria.
         /// </summary>
         [JsonPropertyName("description")]
-        public string Description { get; private set; }
+        public string Description { get; set; }
 
         /// <summary>
         /// Gets the amount of the criteria.
         /// </summary>
         [JsonPropertyName("amount")]
-        public int Amount { get; private set; }
+        public int Amount { get; set; }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Achievement/AchievementMedia.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Achievement/AchievementMedia.cs
@@ -11,12 +11,12 @@ namespace ArgentPonyWarcraftClient
         /// Gets links for the achievement media.
         /// </summary>
         [JsonPropertyName("_links")]
-        public Links Links { get; private set; }
+        public Links Links { get; set; }
 
         /// <summary>
         /// Gets a collection of media assets.
         /// </summary>
         [JsonPropertyName("assets")]
-        public Asset[] Assets { get; private set; }
+        public Asset[] Assets { get; set; }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Achievement/AchievementReference.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Achievement/AchievementReference.cs
@@ -11,18 +11,18 @@ namespace ArgentPonyWarcraftClient
         /// Gets the key for this achievement.
         /// </summary>
         [JsonPropertyName("key")]
-        public Self Key { get; private set; }
+        public Self Key { get; set; }
 
         /// <summary>
         /// Gets the name of this achievement.
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get; private set; }
+        public string Name { get; set; }
 
         /// <summary>
         /// Gets the ID of this achievement.
         /// </summary>
         [JsonPropertyName("id")]
-        public int Id { get; private set; }
+        public int Id { get; set; }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Achievement/AchievementsIndex.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Achievement/AchievementsIndex.cs
@@ -11,12 +11,12 @@ namespace ArgentPonyWarcraftClient
         /// Gets links for the index of achievements.
         /// </summary>
         [JsonPropertyName("_links")]
-        public Links Links { get; private set; }
+        public Links Links { get; set; }
 
         /// <summary>
         /// Gets references to achievements.
         /// </summary>
         [JsonPropertyName("achievements")]
-        public AchievementReference[] Achievements { get; private set; }
+        public AchievementReference[] Achievements { get; set; }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Achievement/AggregatesByFaction.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Achievement/AggregatesByFaction.cs
@@ -11,12 +11,12 @@ namespace ArgentPonyWarcraftClient
         /// Gets the aggregates for the Alliance.
         /// </summary>
         [JsonPropertyName("alliance")]
-        public FactionAchievementAggregates Alliance { get; private set; }
+        public FactionAchievementAggregates Alliance { get; set; }
 
         /// <summary>
         /// Gets the aggregates for the Horde.
         /// </summary>
         [JsonPropertyName("horde")]
-        public FactionAchievementAggregates Horde { get; private set; }
+        public FactionAchievementAggregates Horde { get; set; }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Achievement/FactionAchievementAggregates.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Achievement/FactionAchievementAggregates.cs
@@ -11,12 +11,12 @@ namespace ArgentPonyWarcraftClient
         /// Gets the quantity.
         /// </summary>
         [JsonPropertyName("quantity")]
-        public int Quantity { get; private set; }
+        public int Quantity { get; set; }
 
         /// <summary>
         /// Gets the number of points.
         /// </summary>
         [JsonPropertyName("points")]
-        public int Points { get; private set; }
+        public int Points { get; set; }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/AzeriteEssence/AzeriteEssenceMedia.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/AzeriteEssence/AzeriteEssenceMedia.cs
@@ -11,13 +11,13 @@ namespace ArgentPonyWarcraftClient
         /// Gets links for the azerite essence media.
         /// </summary>
         [JsonPropertyName("_links")]
-        public Links Links { get; private set; }
+        public Links Links { get; set; }
 
         /// <summary>
         /// Gets a collection of media assets.
         /// </summary>
         [JsonPropertyName("assets")]
-        public Asset[] Assets { get; private set; }
+        public Asset[] Assets { get; set; }
 
         /// <summary>
         /// Gets the ID of the azerite essence.

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Creature/CreatureDisplayMedia.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Creature/CreatureDisplayMedia.cs
@@ -11,13 +11,13 @@ namespace ArgentPonyWarcraftClient
         /// Gets links for the creature display media.
         /// </summary>
         [JsonPropertyName("_links")]
-        public Links Links { get; private set; }
+        public Links Links { get; set; }
 
         /// <summary>
         /// Gets a collection of media assets.
         /// </summary>
         [JsonPropertyName("assets")]
-        public Asset[] Assets { get; private set; }
+        public Asset[] Assets { get; set; }
 
         /// <summary>
         /// Gets the ID of the creature display.

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Creature/CreatureFamilyMedia.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Creature/CreatureFamilyMedia.cs
@@ -11,13 +11,13 @@ namespace ArgentPonyWarcraftClient
         /// Gets links for the creature family media.
         /// </summary>
         [JsonPropertyName("_links")]
-        public Links Links { get; private set; }
+        public Links Links { get; set; }
 
         /// <summary>
         /// Gets a collection of media assets.
         /// </summary>
         [JsonPropertyName("assets")]
-        public Asset[] Assets { get; private set; }
+        public Asset[] Assets { get; set; }
 
         /// <summary>
         /// Gets the ID of the creature family.

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/GuildCrest/GuildCrestBorderMedia.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/GuildCrest/GuildCrestBorderMedia.cs
@@ -11,13 +11,13 @@ namespace ArgentPonyWarcraftClient
         /// Gets links for the guild crest border media.
         /// </summary>
         [JsonPropertyName("_links")]
-        public Links Links { get; private set; }
+        public Links Links { get; set; }
 
         /// <summary>
         /// Gets a collection of media assets.
         /// </summary>
         [JsonPropertyName("assets")]
-        public Asset[] Assets { get; private set; }
+        public Asset[] Assets { get; set; }
 
         /// <summary>
         /// Gets the ID of the guild crest border.

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/GuildCrest/GuildCrestEmblemMedia.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/GuildCrest/GuildCrestEmblemMedia.cs
@@ -11,13 +11,13 @@ namespace ArgentPonyWarcraftClient
         /// Gets links for the guild crest emblem media.
         /// </summary>
         [JsonPropertyName("_links")]
-        public Links Links { get; private set; }
+        public Links Links { get; set; }
 
         /// <summary>
         /// Gets a collection of media assets.
         /// </summary>
         [JsonPropertyName("assets")]
-        public Asset[] Assets { get; private set; }
+        public Asset[] Assets { get; set; }
 
         /// <summary>
         /// Gets the ID of the guild crest emblem.

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Item/ItemClassesIndex.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Item/ItemClassesIndex.cs
@@ -11,12 +11,12 @@ namespace ArgentPonyWarcraftClient
         /// Gets links for the index of item classes.
         /// </summary>
         [JsonPropertyName("_links")]
-        public Links Links { get; private set; }
+        public Links Links { get; set; }
 
         /// <summary>
         /// Gets references to item classes.
         /// </summary>
         [JsonPropertyName("item_classes")]
-        public ItemClassReference[] ItemClasses { get; private set; }
+        public ItemClassReference[] ItemClasses { get; set; }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Item/ItemMedia.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Item/ItemMedia.cs
@@ -11,13 +11,13 @@ namespace ArgentPonyWarcraftClient
         /// Gets links for the achievement media.
         /// </summary>
         [JsonPropertyName("_links")]
-        public Links Links { get; private set; }
+        public Links Links { get; set; }
 
         /// <summary>
         /// Gets a collection of media assets.
         /// </summary>
         [JsonPropertyName("assets")]
-        public Asset[] Assets { get; private set; }
+        public Asset[] Assets { get; set; }
 
         /// <summary>
         /// Gets the ID of the item.

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Item/ItemSetsIndex.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Item/ItemSetsIndex.cs
@@ -11,7 +11,7 @@ namespace ArgentPonyWarcraftClient
         /// Gets links for the index of item sets.
         /// </summary>
         [JsonPropertyName("_links")]
-        public Links Links { get; private set; }
+        public Links Links { get; set; }
 
         /// <summary>
         /// Gets references to item sets.

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Journal/JournalMedia.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Journal/JournalMedia.cs
@@ -11,12 +11,12 @@ namespace ArgentPonyWarcraftClient
         /// Gets links for the journal instance media.
         /// </summary>
         [JsonPropertyName("_links")]
-        public Links Links { get; private set; }
+        public Links Links { get; set; }
 
         /// <summary>
         /// Gets a collection of media assets.
         /// </summary>
         [JsonPropertyName("assets")]
-        public Asset[] Assets { get; private set; }
+        public Asset[] Assets { get; set; }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/MythicKeystoneAffix/MythicKeystoneAffixMedia.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/MythicKeystoneAffix/MythicKeystoneAffixMedia.cs
@@ -11,13 +11,13 @@ namespace ArgentPonyWarcraftClient
         /// Gets links for the mythic keystone affix media.
         /// </summary>
         [JsonPropertyName("_links")]
-        public Links Links { get; private set; }
+        public Links Links { get; set; }
 
         /// <summary>
         /// Gets a collection of media assets.
         /// </summary>
         [JsonPropertyName("assets")]
-        public Asset[] Assets { get; private set; }
+        public Asset[] Assets { get; set; }
 
         /// <summary>
         /// Gets the ID of the mythic keystone affix.

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Pet/PetAbilityMedia.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Pet/PetAbilityMedia.cs
@@ -11,13 +11,13 @@ namespace ArgentPonyWarcraftClient
         /// Gets links for the pet ability media.
         /// </summary>
         [JsonPropertyName("_links")]
-        public Links Links { get; private set; }
+        public Links Links { get; set; }
 
         /// <summary>
         /// Gets a collection of media assets.
         /// </summary>
         [JsonPropertyName("assets")]
-        public Asset[] Assets { get; private set; }
+        public Asset[] Assets { get; set; }
 
         /// <summary>
         /// Gets the ID of the pet ability.

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/PlayableClass/PlayableClassMedia.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/PlayableClass/PlayableClassMedia.cs
@@ -11,13 +11,13 @@ namespace ArgentPonyWarcraftClient
         /// Gets links for the playable class media.
         /// </summary>
         [JsonPropertyName("_links")]
-        public Links Links { get; private set; }
+        public Links Links { get; set; }
 
         /// <summary>
         /// Gets a collection of media assets.
         /// </summary>
         [JsonPropertyName("assets")]
-        public Asset[] Assets { get; private set; }
+        public Asset[] Assets { get; set; }
 
         /// <summary>
         /// Gets the ID of the playable class.

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/PlayableSpecialization/PlayableSpecializationMedia.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/PlayableSpecialization/PlayableSpecializationMedia.cs
@@ -11,13 +11,13 @@ namespace ArgentPonyWarcraftClient
         /// Gets links for the playable specialization media.
         /// </summary>
         [JsonPropertyName("_links")]
-        public Links Links { get; private set; }
+        public Links Links { get; set; }
 
         /// <summary>
         /// Gets a collection of media assets.
         /// </summary>
         [JsonPropertyName("assets")]
-        public Asset[] Assets { get; private set; }
+        public Asset[] Assets { get; set; }
 
         /// <summary>
         /// Gets the ID of the playable specialization.

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Profession/ProfessionMedia.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Profession/ProfessionMedia.cs
@@ -11,13 +11,13 @@ namespace ArgentPonyWarcraftClient
         /// Gets links for the profession media.
         /// </summary>
         [JsonPropertyName("_links")]
-        public Links Links { get; private set; }
+        public Links Links { get; set; }
 
         /// <summary>
         /// Gets a collection of media assets.
         /// </summary>
         [JsonPropertyName("assets")]
-        public Asset[] Assets { get; private set; }
+        public Asset[] Assets { get; set; }
 
         /// <summary>
         /// Gets the ID of the profession.

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Profession/RecipeMedia.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Profession/RecipeMedia.cs
@@ -11,13 +11,13 @@ namespace ArgentPonyWarcraftClient
         /// Gets links for the recipe media.
         /// </summary>
         [JsonPropertyName("_links")]
-        public Links Links { get; private set; }
+        public Links Links { get; set; }
 
         /// <summary>
         /// Gets a collection of media assets.
         /// </summary>
         [JsonPropertyName("assets")]
-        public Asset[] Assets { get; private set; }
+        public Asset[] Assets { get; set; }
 
         /// <summary>
         /// Gets the ID of the recipe.

--- a/src/ArgentPonyWarcraftClient/Models/Links.cs
+++ b/src/ArgentPonyWarcraftClient/Models/Links.cs
@@ -11,6 +11,6 @@ namespace ArgentPonyWarcraftClient
         /// Gets a self-reference.
         /// </summary>
         [JsonPropertyName("self")]
-        public Self Self { get; private set; }
+        public Self Self { get; set; }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Models/Media.cs
+++ b/src/ArgentPonyWarcraftClient/Models/Media.cs
@@ -11,12 +11,12 @@ namespace ArgentPonyWarcraftClient
         /// Gets the key for the media.
         /// </summary>
         [JsonPropertyName("key")]
-        public Self Key { get; private set; }
+        public Self Key { get; set; }
 
         /// <summary>
         /// Gets the ID of the media.
         /// </summary>
         [JsonPropertyName("id")]
-        public int Id { get; private set; }
+        public int Id { get; set; }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Models/Self.cs
+++ b/src/ArgentPonyWarcraftClient/Models/Self.cs
@@ -12,6 +12,6 @@ namespace ArgentPonyWarcraftClient
         /// Gets a URI for retrieving the data for this object.
         /// </summary>
         [JsonPropertyName("href")]
-        public Uri Href { get; private set; }
+        public Uri Href { get; set; }
     }
 }


### PR DESCRIPTION
Changed private setters to public in model classes for consistency and because System.Text.Json does not currently support them.  See https://github.com/dotnet/runtime/pull/34675 for details, because this will be supported in .NET 5.