### PR TITLE
Unit and integration test compatibility fixes

### DIFF
--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/AuctionHouseApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/AuctionHouseApiTests.cs
@@ -8,7 +8,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async void GetAuctionsAsync_Gets_Auctions()
         {
             IAuctionHouseApi warcraftClient = ClientFactory.BuildClient();
-            RequestResult<AuctionsIndex> result = await warcraftClient.GetAuctionsAsync(1146, "dynamic-us");
+            RequestResult<AuctionsIndex> result = await warcraftClient.GetAuctionsAsync(4, "dynamic-us");
             Assert.NotNull(result.Value);
         }
     }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/TalentApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/TalentApiTests.cs
@@ -32,7 +32,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async void GetPvpTalentAsync_Gets_PvpTalent()
         {
             ITalentApi warcraftClient = ClientFactory.BuildClient();
-            RequestResult<PvpTalent> result = await warcraftClient.GetPvpTalentAsync(3, "static-us");
+            RequestResult<PvpTalent> result = await warcraftClient.GetPvpTalentAsync(11, "static-us");
             Assert.NotNull(result.Value);
         }
     }

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/AuctionHouseApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/AuctionHouseApiTests.cs
@@ -9,10 +9,10 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         public async void GetAuctionsAsync_Gets_Auctions()
         {
             IAuctionHouseApi warcraftClient = ClientFactory.BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/data/wow/connected-realm/1146/auctions?namespace=dynamic-us&locale=en_US",
+                requestUri: "https://us.api.blizzard.com/data/wow/connected-realm/4/auctions?namespace=dynamic-us&locale=en_US",
                 responseContent: Resources.AuctionsResponse);
 
-            RequestResult<AuctionsIndex> result = await warcraftClient.GetAuctionsAsync(1146, "dynamic-us");
+            RequestResult<AuctionsIndex> result = await warcraftClient.GetAuctionsAsync(4, "dynamic-us");
             Assert.NotNull(result.Value);
         }
     }

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/TalentApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/TalentApiTests.cs
@@ -42,10 +42,10 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         public async void GetPvpTalentAsync_Gets_PvpTalent()
         {
             ITalentApi warcraftClient = ClientFactory.BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/data/wow/pvp-talent/3?namespace=static-us&locale=en_US",
+                requestUri: "https://us.api.blizzard.com/data/wow/pvp-talent/11?namespace=static-us&locale=en_US",
                 responseContent: Resources.PvpTalentResponse);
 
-            RequestResult<PvpTalent> result = await warcraftClient.GetPvpTalentAsync(3, "static-us");
+            RequestResult<PvpTalent> result = await warcraftClient.GetPvpTalentAsync(11, "static-us");
             Assert.NotNull(result.Value);
         }
     }

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
@@ -2886,20 +2886,21 @@ namespace ArgentPonyWarcraftClient.Tests.Properties {
         ///   Looks up a localized string similar to {
         ///  &quot;_links&quot;: {
         ///    &quot;self&quot;: {
-        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/pvp-talent/3?namespace=static-8.3.0_32861-us&quot;
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/pvp-talent/11?namespace=static-9.0.2_36532-us&quot;
         ///    }
         ///  },
-        ///  &quot;id&quot;: 3,
+        ///  &quot;id&quot;: 11,
         ///  &quot;spell&quot;: {
         ///    &quot;key&quot;: {
-        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/spell/208683?namespace=static-8.3.0_32861-us&quot;
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/spell/199954?namespace=static-9.0.2_36532-us&quot;
         ///    },
-        ///    &quot;name&quot;: &quot;Gladiator&apos;s Medallion&quot;,
-        ///    &quot;id&quot;: 208683
+        ///    &quot;name&quot;: &quot;Bane of Fragility&quot;,
+        ///    &quot;id&quot;: 199954
         ///  },
         ///  &quot;playable_specialization&quot;: {
         ///    &quot;key&quot;: {
-        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/playable-specialization/105?namespace=static-8.3.0_32861-us&quot; [rest of string was truncated]&quot;;.
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/playable-specialization/265?namespace=static-9.0.2_36532-us&quot;
+        /// [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string PvpTalentResponse {
             get {

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
@@ -280,26 +280,26 @@ namespace ArgentPonyWarcraftClient.Tests.Properties {
         ///   Looks up a localized string similar to {
         ///  &quot;_links&quot;: {
         ///    &quot;self&quot;: {
-        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/connected-realm/1146/auctions?namespace=dynamic-us&quot;
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/connected-realm/4/auctions?namespace=dynamic-us&quot;
         ///    }
         ///  },
         ///  &quot;connected_realm&quot;: {
-        ///    &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/connected-realm/1146?namespace=dynamic-us&quot;
+        ///    &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/connected-realm/4?namespace=dynamic-us&quot;
         ///  },
         ///  &quot;auctions&quot;: [
         ///    {
-        ///      &quot;id&quot;: 568957532,
+        ///      &quot;id&quot;: 37781919,
         ///      &quot;item&quot;: {
-        ///        &quot;id&quot;: 168185
+        ///        &quot;id&quot;: 86280,
+        ///        &quot;context&quot;: 0,
+        ///        &quot;modifiers&quot;: [
+        ///          {
+        ///            &quot;type&quot;: 28,
+        ///            &quot;value&quot;: 2008
+        ///          }
+        ///        ]
         ///      },
-        ///      &quot;quantity&quot;: 7,
-        ///      &quot;unit_price&quot;: 345000,
-        ///      &quot;time_left&quot;: &quot;SHORT&quot;
-        ///    },
-        ///    {
-        ///      &quot;id&quot;: 568957534,
-        ///      &quot;item&quot;: {
-        ///      [rest of string was truncated]&quot;;.
+        ///      &quot;buyo [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string AuctionsResponse {
             get {

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
@@ -61800,35 +61800,31 @@
     <value>{
   "_links": {
     "self": {
-      "href": "https://us.api.blizzard.com/data/wow/pvp-talent/3?namespace=static-8.3.0_32861-us"
+      "href": "https://us.api.blizzard.com/data/wow/pvp-talent/11?namespace=static-9.0.2_36532-us"
     }
   },
-  "id": 3,
+  "id": 11,
   "spell": {
     "key": {
-      "href": "https://us.api.blizzard.com/data/wow/spell/208683?namespace=static-8.3.0_32861-us"
+      "href": "https://us.api.blizzard.com/data/wow/spell/199954?namespace=static-9.0.2_36532-us"
     },
-    "name": "Gladiator's Medallion",
-    "id": 208683
+    "name": "Bane of Fragility",
+    "id": 199954
   },
   "playable_specialization": {
     "key": {
-      "href": "https://us.api.blizzard.com/data/wow/playable-specialization/105?namespace=static-8.3.0_32861-us"
+      "href": "https://us.api.blizzard.com/data/wow/playable-specialization/265?namespace=static-9.0.2_36532-us"
     },
-    "name": "Restoration",
-    "id": 105
+    "name": "Affliction",
+    "id": 265
   },
-  "overrides_spell": {
-    "key": {
-      "href": "https://us.api.blizzard.com/data/wow/spell/195710?namespace=static-8.3.0_32861-us"
-    },
-    "name": "Honorable Medallion",
-    "id": 195710
-  },
-  "description": "Removes all movement impairing effects and all effects which cause loss of control of your character while in PvP combat.",
-  "unlock_player_level": 0,
+  "description": "Reduces the target's maximum health by up to 15% for 10 sec.",
+  "unlock_player_level": 25,
   "compatible_slots": [
-    1
+    1,
+    2,
+    3,
+    4
   ]
 }</value>
   </data>

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
@@ -54094,364 +54094,128 @@
     <value>{
   "_links": {
     "self": {
-      "href": "https://us.api.blizzard.com/data/wow/connected-realm/1146/auctions?namespace=dynamic-us"
+      "href": "https://us.api.blizzard.com/data/wow/connected-realm/4/auctions?namespace=dynamic-us"
     }
   },
   "connected_realm": {
-    "href": "https://us.api.blizzard.com/data/wow/connected-realm/1146?namespace=dynamic-us"
+    "href": "https://us.api.blizzard.com/data/wow/connected-realm/4?namespace=dynamic-us"
   },
   "auctions": [
     {
-      "id": 568957532,
+      "id": 37781919,
       "item": {
-        "id": 168185
-      },
-      "quantity": 7,
-      "unit_price": 345000,
-      "time_left": "SHORT"
-    },
-    {
-      "id": 568957534,
-      "item": {
-        "id": 175007,
-        "context": 3,
-        "bonus_lists": [
-          4822,
-          6578,
-          6579,
-          6564,
-          6513,
-          1487,
-          4786
+        "id": 86280,
+        "context": 0,
+        "modifiers": [
+          {
+            "type": 28,
+            "value": 2008
+          }
         ]
       },
-      "bid": 450000000,
-      "buyout": 600000000,
+      "buyout": 112600,
       "quantity": 1,
       "time_left": "SHORT"
     },
     {
-      "id": 568957571,
+      "id": 37793634,
       "item": {
-        "id": 167738
+        "id": 82265,
+        "context": 36,
+        "bonus_lists": [
+          1687,
+          4767
+        ],
+        "modifiers": [
+          {
+            "type": 9,
+            "value": 50
+          }
+        ]
       },
+      "buyout": 2346900,
       "quantity": 1,
-      "unit_price": 149100,
-      "time_left": "SHORT"
+      "time_left": "MEDIUM"
     },
     {
-      "id": 568957585,
+      "id": 37999300,
       "item": {
-        "id": 169334
+        "id": 67127,
+        "context": 5,
+        "bonus_lists": [
+          6658
+        ],
+        "modifiers": [
+          {
+            "type": 9,
+            "value": 35
+          },
+          {
+            "type": 28,
+            "value": 1029
+          }
+        ]
       },
-      "quantity": 2,
-      "unit_price": 11500,
-      "time_left": "SHORT"
+      "buyout": 15000000,
+      "quantity": 1,
+      "time_left": "LONG"
     },
     {
-      "id": 568957676,
+      "id": 38040082,
+      "item": {
+        "id": 36131,
+        "context": 0,
+        "bonus_lists": [
+          6654,
+          1708
+        ],
+        "modifiers": [
+          {
+            "type": 9,
+            "value": 30
+          },
+          {
+            "type": 28,
+            "value": 49
+          }
+        ]
+      },
+      "bid": 500000,
+      "buyout": 1003700,
+      "quantity": 1,
+      "time_left": "VERY_LONG"
+    },
+    {
+      "id": 37885614,
       "item": {
         "id": 82800,
         "context": 0,
         "modifiers": [
           {
             "type": 6,
-            "value": 95174
+            "value": 62217
           }
         ],
-        "pet_breed_id": 7,
+        "pet_breed_id": 21,
         "pet_level": 1,
-        "pet_quality_id": 3,
-        "pet_species_id": 2834
+        "pet_quality_id": 2,
+        "pet_species_id": 194
       },
-      "buyout": 29000000,
+      "buyout": 1008500,
       "quantity": 1,
-      "time_left": "SHORT"
+      "time_left": "LONG"
     },
     {
-      "id": 568958789,
+      "id": 38731280,
       "item": {
-        "id": 11974,
-        "context": 53,
+        "id": 39507,
+        "context": 11,
         "bonus_lists": [
-          1680,
-          4277
-        ],
-        "modifiers": [
-          {
-            "type": 9,
-            "value": 120
-          }
+          1692
         ]
       },
-      "buyout": 28404200,
+      "buyout": 99000000,
       "quantity": 1,
-      "time_left": "SHORT"
-    },
-    {
-      "id": 568958792,
-      "item": {
-        "id": 14426,
-        "context": 53,
-        "bonus_lists": [
-          4277
-        ],
-        "modifiers": [
-          {
-            "type": 9,
-            "value": 120
-          }
-        ]
-      },
-      "buyout": 22268000,
-      "quantity": 1,
-      "time_left": "SHORT"
-    },
-    {
-      "id": 568958795,
-      "item": {
-        "id": 14435,
-        "context": 53,
-        "bonus_lists": [
-          4277
-        ],
-        "modifiers": [
-          {
-            "type": 9,
-            "value": 120
-          }
-        ]
-      },
-      "buyout": 27843700,
-      "quantity": 1,
-      "time_left": "SHORT"
-    },
-    {
-      "id": 568958901,
-      "item": {
-        "id": 82800,
-        "context": 0,
-        "modifiers": [
-          {
-            "type": 6,
-            "value": 94706
-          }
-        ],
-        "pet_breed_id": 6,
-        "pet_level": 1,
-        "pet_quality_id": 3,
-        "pet_species_id": 2833
-      },
-      "buyout": 79650100,
-      "quantity": 1,
-      "time_left": "SHORT"
-    },
-    {
-      "id": 568958903,
-      "item": {
-        "id": 82800,
-        "context": 0,
-        "modifiers": [
-          {
-            "type": 6,
-            "value": 94706
-          }
-        ],
-        "pet_breed_id": 6,
-        "pet_level": 1,
-        "pet_quality_id": 3,
-        "pet_species_id": 2833
-      },
-      "buyout": 79650100,
-      "quantity": 1,
-      "time_left": "SHORT"
-    },
-    {
-      "id": 568958923,
-      "item": {
-        "id": 159959
-      },
-      "quantity": 1,
-      "unit_price": 10000,
-      "time_left": "SHORT"
-    },
-    {
-      "id": 568958940,
-      "item": {
-        "id": 164412,
-        "context": 11
-      },
-      "buyout": 31766700,
-      "quantity": 1,
-      "time_left": "SHORT"
-    },
-    {
-      "id": 568959036,
-      "item": {
-        "id": 164390,
-        "context": 11
-      },
-      "buyout": 50000000,
-      "quantity": 1,
-      "time_left": "SHORT"
-    },
-    {
-      "id": 568959201,
-      "item": {
-        "id": 10302,
-        "context": 0
-      },
-      "buyout": 5775400,
-      "quantity": 1,
-      "time_left": "SHORT"
-    },
-    {
-      "id": 568959205,
-      "item": {
-        "id": 11974,
-        "context": 53,
-        "bonus_lists": [
-          1707,
-          4277
-        ],
-        "modifiers": [
-          {
-            "type": 9,
-            "value": 120
-          }
-        ]
-      },
-      "buyout": 28404200,
-      "quantity": 1,
-      "time_left": "SHORT"
-    },
-    {
-      "id": 568959208,
-      "item": {
-        "id": 12023,
-        "context": 54,
-        "bonus_lists": [
-          1693,
-          4277
-        ],
-        "modifiers": [
-          {
-            "type": 9,
-            "value": 120
-          }
-        ]
-      },
-      "buyout": 24210700,
-      "quantity": 1,
-      "time_left": "SHORT"
-    },
-    {
-      "id": 568959211,
-      "item": {
-        "id": 14207,
-        "context": 54,
-        "bonus_lists": [
-          1693,
-          4277
-        ],
-        "modifiers": [
-          {
-            "type": 9,
-            "value": 120
-          }
-        ]
-      },
-      "buyout": 28231500,
-      "quantity": 1,
-      "time_left": "SHORT"
-    },
-    {
-      "id": 568959212,
-      "item": {
-        "id": 14216,
-        "context": 53,
-        "bonus_lists": [
-          1681,
-          4277
-        ],
-        "modifiers": [
-          {
-            "type": 9,
-            "value": 120
-          }
-        ]
-      },
-      "buyout": 79754700,
-      "quantity": 1,
-      "time_left": "SHORT"
-    },
-    {
-      "id": 568959214,
-      "item": {
-        "id": 14223,
-        "context": 53,
-        "bonus_lists": [
-          1692,
-          4277
-        ],
-        "modifiers": [
-          {
-            "type": 9,
-            "value": 120
-          }
-        ]
-      },
-      "buyout": 43730600,
-      "quantity": 1,
-      "time_left": "SHORT"
-    },
-    {
-      "id": 568959216,
-      "item": {
-        "id": 14228,
-        "context": 54,
-        "bonus_lists": [
-          1677,
-          4277
-        ],
-        "modifiers": [
-          {
-            "type": 9,
-            "value": 120
-          }
-        ]
-      },
-      "buyout": 37519000,
-      "quantity": 1,
-      "time_left": "SHORT"
-    },
-    {
-      "id": 568959217,
-      "item": {
-        "id": 14234,
-        "context": 53,
-        "bonus_lists": [
-          1679,
-          4277
-        ],
-        "modifiers": [
-          {
-            "type": 9,
-            "value": 120
-          }
-        ]
-      },
-      "buyout": 50849600,
-      "quantity": 1,
-      "time_left": "SHORT"
-    },
-    {
-      "id": 569661821,
-      "item": {
-        "id": 79101
-      },
-      "quantity": 1,
-      "unit_price": 76300,
       "time_left": "VERY_LONG"
     }
   ]


### PR DESCRIPTION
Updated the unit and integration tests for the auction house and PvP talents.  The talent and connected realm IDs that were in use for the test are no longer valid, so the tests needed to be updated.