### PR TITLE
Converted tests to return async Task instead of async void

### DIFF
--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/AchievementApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/AchievementApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class AchievementApiTests
     {
         [ResilientFact]
-        public async void GetAchievementCategoriesIndexAsync_Gets_AchievementCategoriesIndex()
+        public async Task GetAchievementCategoriesIndexAsync_Gets_AchievementCategoriesIndex()
         {
             IAchievementApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<AchievementCategoriesIndex> result = await warcraftClient.GetAchievementCategoriesIndexAsync("static-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetAchievementCategoryAsync_Gets_AchievementCategory()
+        public async Task GetAchievementCategoryAsync_Gets_AchievementCategory()
         {
             IAchievementApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<AchievementCategory> result = await warcraftClient.GetAchievementCategoryAsync(81, "static-us");
@@ -21,7 +22,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetAchievementsIndexAsync_Gets_AchievementsIndex()
+        public async Task GetAchievementsIndexAsync_Gets_AchievementsIndex()
         {
             IAchievementApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<AchievementsIndex> result = await warcraftClient.GetAchievementsIndexAsync("static-us");
@@ -29,7 +30,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetAchievementAsync_Gets_Achievement()
+        public async Task GetAchievementAsync_Gets_Achievement()
         {
             IAchievementApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<Achievement> result = await warcraftClient.GetAchievementAsync(6, "static-us");
@@ -37,7 +38,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetAchievementMediaAsync_Gets_AchievementMedia()
+        public async Task GetAchievementMediaAsync_Gets_AchievementMedia()
         {
             IAchievementApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<AchievementMedia> result = await warcraftClient.GetAchievementMediaAsync(6, "static-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/AuctionHouseApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/AuctionHouseApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class AuctionHouseApiTests
     {
         [ResilientFact]
-        public async void GetAuctionsAsync_Gets_Auctions()
+        public async Task GetAuctionsAsync_Gets_Auctions()
         {
             IAuctionHouseApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<AuctionsIndex> result = await warcraftClient.GetAuctionsAsync(4, "dynamic-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/AzeriteEssenceApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/AzeriteEssenceApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class AzeriteEssenceApiTests
     {
         [ResilientFact]
-        public async void GetAzeriteEssencesIndexAsync_Gets_AzeriteEssencesIndex()
+        public async Task GetAzeriteEssencesIndexAsync_Gets_AzeriteEssencesIndex()
         {
             IAzeriteEssenceApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<AzeriteEssencesIndex> result = await warcraftClient.GetAzeriteEssencesIndexAsync("static-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetAzeriteEssenceAsync_Gets_AzeriteEssence()
+        public async Task GetAzeriteEssenceAsync_Gets_AzeriteEssence()
         {
             IAzeriteEssenceApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<AzeriteEssence> result = await warcraftClient.GetAzeriteEssenceAsync(2, "static-us");
@@ -21,7 +22,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetAzeriteEssenceMediaAsync_Gets_AzeriteEssenceMedia()
+        public async Task GetAzeriteEssenceMediaAsync_Gets_AzeriteEssenceMedia()
         {
             IAzeriteEssenceApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<AzeriteEssenceMedia> result = await warcraftClient.GetAzeriteEssenceMediaAsync(2, "static-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/ConnectedRealmApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/ConnectedRealmApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class ConnectedRealmApiTests
     {
         [ResilientFact]
-        public async void GetPlayableRacesIndexAsync_Gets_PlayableRacesIndex()
+        public async Task GetPlayableRacesIndexAsync_Gets_PlayableRacesIndex()
         {
             IConnectedRealmApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<ConnectedRealmsIndex> result = await warcraftClient.GetConnectedRealmsIndexAsync("dynamic-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetRealmAsync_Gets_Realm()
+        public async Task GetRealmAsync_Gets_Realm()
         {
             IConnectedRealmApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<ConnectedRealm> result = await warcraftClient.GetConnectedRealmAsync(11, "dynamic-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/CreatureApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/CreatureApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class CreatureApiTests
     {
         [ResilientFact]
-        public async void GetCreatureFamiliesIndexAsync_Gets_CreatureFamiliesIndex()
+        public async Task GetCreatureFamiliesIndexAsync_Gets_CreatureFamiliesIndex()
         {
             ICreatureApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CreatureFamiliesIndex> result = await warcraftClient.GetCreatureFamiliesIndexAsync("static-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetCreatureFamilyAsync_Gets_CreatureFamily()
+        public async Task GetCreatureFamilyAsync_Gets_CreatureFamily()
         {
             ICreatureApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CreatureFamily> result = await warcraftClient.GetCreatureFamilyAsync(1, "static-us");
@@ -21,7 +22,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetCreatureTypesIndexAsync_Gets_CreatureTypesIndex()
+        public async Task GetCreatureTypesIndexAsync_Gets_CreatureTypesIndex()
         {
             ICreatureApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CreatureTypesIndex> result = await warcraftClient.GetCreatureTypesIndexAsync("static-us");
@@ -29,7 +30,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetCreatureTypeAsync_Gets_CreatureType()
+        public async Task GetCreatureTypeAsync_Gets_CreatureType()
         {
             ICreatureApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CreatureType> result = await warcraftClient.GetCreatureTypeAsync(1, "static-us");
@@ -37,7 +38,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetCreatureAsync_Gets_Creature()
+        public async Task GetCreatureAsync_Gets_Creature()
         {
             ICreatureApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<Creature> result = await warcraftClient.GetCreatureAsync(42722, "static-us");
@@ -45,7 +46,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetCreatureDisplayMediaAsync_Gets_CreatureDisplayMedia()
+        public async Task GetCreatureDisplayMediaAsync_Gets_CreatureDisplayMedia()
         {
             ICreatureApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CreatureDisplayMedia> result = await warcraftClient.GetCreatureDisplayMediaAsync(30221, "static-us");
@@ -53,7 +54,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetCreatureFamilyMediaAsync_Gets_CreatureFamilyMedia()
+        public async Task GetCreatureFamilyMediaAsync_Gets_CreatureFamilyMedia()
         {
             ICreatureApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CreatureFamilyMedia> result = await warcraftClient.GetCreatureFamilyMediaAsync(1, "static-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/GuildCrestApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/GuildCrestApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class GuildCrestApiTests
     {
         [ResilientFact]
-        public async void GetGuildCrestComponentsIndexAsync_Gets_GuildCrestComponentsIndex()
+        public async Task GetGuildCrestComponentsIndexAsync_Gets_GuildCrestComponentsIndex()
         {
             IGuildCrestApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<GuildCrestComponentsIndex> result = await warcraftClient.GetGuildCrestComponentsIndexAsync("static-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetGuildCrestBorderMediaAsync_Gets_GuildCrestBorderMedia()
+        public async Task GetGuildCrestBorderMediaAsync_Gets_GuildCrestBorderMedia()
         {
             IGuildCrestApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<GuildCrestBorderMedia> result = await warcraftClient.GetGuildCrestBorderMediaAsync(0, "static-us");
@@ -21,7 +22,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetGuildCrestEmblemMediaAsync_Gets_GuildCrestEmblemMedia()
+        public async Task GetGuildCrestEmblemMediaAsync_Gets_GuildCrestEmblemMedia()
         {
             IGuildCrestApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<GuildCrestEmblemMedia> result = await warcraftClient.GetGuildCrestEmblemMediaAsync(0, "static-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/ItemApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/ItemApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class ItemApiTests
     {
         [ResilientFact]
-        public async void GetItemClassesIndexAsync_Gets_ItemClassesIndex()
+        public async Task GetItemClassesIndexAsync_Gets_ItemClassesIndex()
         {
             IItemApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<ItemClassesIndex> result = await warcraftClient.GetItemClassesIndexAsync("static-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetItemClassAsync_Gets_ItemClass()
+        public async Task GetItemClassAsync_Gets_ItemClass()
         {
             IItemApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<ItemClass> result = await warcraftClient.GetItemClassAsync(0, "static-us");
@@ -21,7 +22,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetItemSetsIndexAsync_Gets_ItemSetsIndex()
+        public async Task GetItemSetsIndexAsync_Gets_ItemSetsIndex()
         {
             IItemApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<ItemSetsIndex> result = await warcraftClient.GetItemSetsIndexAsync("static-us");
@@ -29,7 +30,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetItemSetAsync_Gets_ItemSet()
+        public async Task GetItemSetAsync_Gets_ItemSet()
         {
             IItemApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<ItemSet> result = await warcraftClient.GetItemSetAsync(1, "static-us");
@@ -37,7 +38,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetItemSubclassAsync_Gets_ItemSubclass()
+        public async Task GetItemSubclassAsync_Gets_ItemSubclass()
         {
             IItemApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<ItemSubclass> result = await warcraftClient.GetItemSubclassAsync(0, 0, "static-us");
@@ -45,7 +46,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetItemAsync_Gets_Item()
+        public async Task GetItemAsync_Gets_Item()
         {
             IItemApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<Item> result = await warcraftClient.GetItemAsync(19019, "static-us");
@@ -53,7 +54,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetItemMediaAsync_Gets_Item()
+        public async Task GetItemMediaAsync_Gets_Item()
         {
             IItemApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<ItemMedia> result = await warcraftClient.GetItemMediaAsync(19019, "static-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/JournalApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/JournalApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class JournalApiTests
     {
         [ResilientFact]
-        public async void GetJournalExpansionsIndexAsync_Gets_JournalExpansions()
+        public async Task GetJournalExpansionsIndexAsync_Gets_JournalExpansions()
         {
             IJournalApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<JournalExpansionsIndex> result = await warcraftClient.GetJournalExpansionsIndexAsync("static-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetJournalExpansionAsync_Gets_JournalExpansion()
+        public async Task GetJournalExpansionAsync_Gets_JournalExpansion()
         {
             IJournalApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<JournalExpansion> result = await warcraftClient.GetJournalExpansionAsync(68, "static-us");
@@ -21,7 +22,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetJournalEncountersIndexAsync_Gets_JournalEncounters()
+        public async Task GetJournalEncountersIndexAsync_Gets_JournalEncounters()
         {
             IJournalApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<JournalEncountersIndex> result = await warcraftClient.GetJournalEncountersIndexAsync("static-us");
@@ -29,7 +30,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetJournalEncounterAsync_Gets_Encounter()
+        public async Task GetJournalEncounterAsync_Gets_Encounter()
         {
             IJournalApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<Encounter> result = await warcraftClient.GetJournalEncounterAsync(89, "static-us");
@@ -37,7 +38,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetJournalInstancesIndexAsync_Gets_JournalInstances()
+        public async Task GetJournalInstancesIndexAsync_Gets_JournalInstances()
         {
             IJournalApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<JournalInstancesIndex> result = await warcraftClient.GetJournalInstancesIndexAsync("static-us");
@@ -45,7 +46,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetJournalInstanceAsync_Gets_Instance()
+        public async Task GetJournalInstanceAsync_Gets_Instance()
         {
             IJournalApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<Instance> result = await warcraftClient.GetJournalInstanceAsync(63, "static-us");
@@ -53,7 +54,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetJournalInstanceMediaAsync_Gets_InstanceMedia()
+        public async Task GetJournalInstanceMediaAsync_Gets_InstanceMedia()
         {
             IJournalApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<JournalInstanceMedia> result = await warcraftClient.GetJournalInstanceMediaAsync(63, "static-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/MountApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/MountApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class MountApiTests
     {
         [ResilientFact]
-        public async void GetMountsIndexAsync_Gets_MountsIndex()
+        public async Task GetMountsIndexAsync_Gets_MountsIndex()
         {
             IMountApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<MountsIndex> result = await warcraftClient.GetMountsIndexAsync("static-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetMountAsync_Gets_Mount()
+        public async Task GetMountAsync_Gets_Mount()
         {
             IMountApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<Mount> result = await warcraftClient.GetMountAsync(6, "static-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/MythicKeystoneAffixApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/MythicKeystoneAffixApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class MythicKeystoneAffixApiTests
     {
         [ResilientFact]
-        public async void GetMythicKeystoneLeaderboardsIndexAsync_Gets_MythicKeystoneLeaderboardsIndex()
+        public async Task GetMythicKeystoneLeaderboardsIndexAsync_Gets_MythicKeystoneLeaderboardsIndex()
         {
             IMythicKeystoneAffixApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<MythicKeystoneAffixesIndex> result = await warcraftClient.GetMythicKeystoneAffixesIndexAsync("static-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetMythicKeystoneAffixAsync_Gets_MythicKeystoneAffix()
+        public async Task GetMythicKeystoneAffixAsync_Gets_MythicKeystoneAffix()
         {
             IMythicKeystoneAffixApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<MythicKeystoneAffix> result = await warcraftClient.GetMythicKeystoneAffixAsync(1, "static-us");
@@ -21,7 +22,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetMythicKeystoneAffixMediaAsync_Gets_MythicKeystoneAffixMedia()
+        public async Task GetMythicKeystoneAffixMediaAsync_Gets_MythicKeystoneAffixMedia()
         {
             IMythicKeystoneAffixApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<MythicKeystoneAffixMedia> result = await warcraftClient.GetMythicKeystoneAffixMediaAsync(1, "static-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/MythicKeystoneDungeonApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/MythicKeystoneDungeonApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class MythicKeystoneDungeonApiTests
     {
         [ResilientFact]
-        public async void GetMythicKeystoneDungeonsIndexAsync_Gets_MythicKeystoneDungeonsIndex()
+        public async Task GetMythicKeystoneDungeonsIndexAsync_Gets_MythicKeystoneDungeonsIndex()
         {
             IMythicKeystoneDungeonApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<MythicKeystoneDungeonsIndex> result = await warcraftClient.GetMythicKeystoneDungeonsIndexAsync("dynamic-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetMythicKeystoneDungeonAsync_Gets_MythicKeystoneDungeon()
+        public async Task GetMythicKeystoneDungeonAsync_Gets_MythicKeystoneDungeon()
         {
             IMythicKeystoneDungeonApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<MythicKeystoneDungeon> result = await warcraftClient.GetMythicKeystoneDungeonAsync(353, "dynamic-us");
@@ -21,7 +22,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetMythicKeystoneIndexAsync_Gets_MythicKeystoneIndex()
+        public async Task GetMythicKeystoneIndexAsync_Gets_MythicKeystoneIndex()
         {
             IMythicKeystoneDungeonApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<MythicKeystoneIndex> result = await warcraftClient.GetMythicKeystoneIndexAsync("dynamic-us");
@@ -29,7 +30,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetMythicKeystonePeriodsIndexAsync_Gets_MythicKeystonePeriodsIndex()
+        public async Task GetMythicKeystonePeriodsIndexAsync_Gets_MythicKeystonePeriodsIndex()
         {
             IMythicKeystoneDungeonApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<MythicKeystonePeriodsIndex> result = await warcraftClient.GetMythicKeystonePeriodsIndexAsync("dynamic-us");
@@ -37,7 +38,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetMythicKeystonePeriodAsync_Gets_MythicKeystonePeriod()
+        public async Task GetMythicKeystonePeriodAsync_Gets_MythicKeystonePeriod()
         {
             IMythicKeystoneDungeonApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<MythicKeystonePeriod> result = await warcraftClient.GetMythicKeystonePeriodAsync(641, "dynamic-us");
@@ -45,7 +46,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetMythicKeystoneSeasonsIndexAsync_Gets_MythicKeystoneSeasonsIndex()
+        public async Task GetMythicKeystoneSeasonsIndexAsync_Gets_MythicKeystoneSeasonsIndex()
         {
             IMythicKeystoneDungeonApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<MythicKeystoneSeasonsIndex> result = await warcraftClient.GetMythicKeystoneSeasonsIndexAsync("dynamic-us");
@@ -53,7 +54,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetMythicKeystoneSeasonAsync_Gets_MythicKeystoneSeason()
+        public async Task GetMythicKeystoneSeasonAsync_Gets_MythicKeystoneSeason()
         {
             IMythicKeystoneDungeonApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<MythicKeystoneSeason> result = await warcraftClient.GetMythicKeystoneSeasonAsync(1, "dynamic-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/MythicKeystoneLeaderboardApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/MythicKeystoneLeaderboardApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class MythicKeystoneLeaderboardApiTests
     {
         [ResilientFact]
-        public async void GetMythicKeystoneLeaderboardsIndexAsync_Gets_MythicKeystoneLeaderboardsIndex()
+        public async Task GetMythicKeystoneLeaderboardsIndexAsync_Gets_MythicKeystoneLeaderboardsIndex()
         {
             IMythicKeystoneLeaderboardApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<MythicKeystoneLeaderboardsIndex> result = await warcraftClient.GetMythicKeystoneLeaderboardsIndexAsync(11, "dynamic-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetMythicKeystoneLeaderboard_Gets_MythicKeystoneLeaderboard()
+        public async Task GetMythicKeystoneLeaderboard_Gets_MythicKeystoneLeaderboard()
         {
             IMythicKeystoneLeaderboardApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<MythicKeystoneLeaderboard> result = await warcraftClient.GetMythicKeystoneLeaderboard(11, 197, 641, "dynamic-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/MythicRaidLeaderboardApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/MythicRaidLeaderboardApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class MythicRaidLeaderboardApiTests
     {
         [ResilientFact]
-        public async void GetMythicKeystoneLeaderboardsIndexAsync_Gets_MythicKeystoneLeaderboardsIndex()
+        public async Task GetMythicKeystoneLeaderboardsIndexAsync_Gets_MythicKeystoneLeaderboardsIndex()
         {
             IMythicRaidLeaderboardApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<MythicRaidLeaderboard> result = await warcraftClient.GetMythicRaidLeaderboardAsync("uldir", "alliance", "dynamic-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PetApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PetApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class PetApiTests
     {
         [ResilientFact]
-        public async void GetPetsIndexAsync_Gets_PetsIndex()
+        public async Task GetPetsIndexAsync_Gets_PetsIndex()
         {
             IPetApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<PetsIndex> result = await warcraftClient.GetPetsIndexAsync("static-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetPetAsync_Gets_Pet()
+        public async Task GetPetAsync_Gets_Pet()
         {
             IPetApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<Pet> result = await warcraftClient.GetPetAsync(39, "static-us");
@@ -21,7 +22,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetPetAbilitiesIndexAsync_Gets_PetAbilitiesIndex()
+        public async Task GetPetAbilitiesIndexAsync_Gets_PetAbilitiesIndex()
         {
             IPetApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<PetAbilitiesIndex> result = await warcraftClient.GetPetAbilitiesIndexAsync("static-us");
@@ -29,7 +30,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetPetAbilityAsync_Gets_PetAbility()
+        public async Task GetPetAbilityAsync_Gets_PetAbility()
         {
             IPetApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<PetAbility> result = await warcraftClient.GetPetAbilityAsync(110, "static-us");
@@ -37,7 +38,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetPetAbilityMediaAsync_Gets_PetAbilityMedia()
+        public async Task GetPetAbilityMediaAsync_Gets_PetAbilityMedia()
         {
             IPetApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<PetAbilityMedia> result = await warcraftClient.GetPetAbilityMediaAsync(110, "static-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PlayableClassApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PlayableClassApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class PlayableClassApiTests
     {
         [ResilientFact]
-        public async void GetPlayableClassesIndexAsync_Gets_PlayableClassesIndex()
+        public async Task GetPlayableClassesIndexAsync_Gets_PlayableClassesIndex()
         {
             IPlayableClassApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<PlayableClassesIndex> result = await warcraftClient.GetPlayableClassesIndexAsync("static-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetPlayableClassAsync_Gets_PlayableClass()
+        public async Task GetPlayableClassAsync_Gets_PlayableClass()
         {
             IPlayableClassApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<PlayableClass> result = await warcraftClient.GetPlayableClassAsync(7, "static-us");
@@ -21,7 +22,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetPlayableClassMediaAsync_Gets_PlayableClassMedia()
+        public async Task GetPlayableClassMediaAsync_Gets_PlayableClassMedia()
         {
             IPlayableClassApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<PlayableClassMedia> result = await warcraftClient.GetPlayableClassMediaAsync(7, "static-us");
@@ -29,7 +30,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetPvpTalentSlotsAsync_Gets_PvpTalentSlots()
+        public async Task GetPvpTalentSlotsAsync_Gets_PvpTalentSlots()
         {
             IPlayableClassApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<PvpTalentSlots> result = await warcraftClient.GetPvpTalentSlotsAsync(7, "static-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PlayableRaceApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PlayableRaceApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class PlayableRaceApiTests
     {
         [ResilientFact]
-        public async void GetPlayableRacesIndexAsync_Gets_PlayableRacesIndex()
+        public async Task GetPlayableRacesIndexAsync_Gets_PlayableRacesIndex()
         {
             IPlayableRaceApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<PlayableRacesIndex> result = await warcraftClient.GetPlayableRacesIndexAsync("static-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetPlayableRaceAsync_Gets_PlayableRace()
+        public async Task GetPlayableRaceAsync_Gets_PlayableRace()
         {
             IPlayableRaceApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<PlayableRace> result = await warcraftClient.GetPlayableRaceAsync(2, "static-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PlayableSpecializationApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PlayableSpecializationApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class PlayableSpecializationApiTests
     {
         [ResilientFact]
-        public async void GetPlayableSpecializationsIndexAsync_Gets_PlayableSpecializationsIndex()
+        public async Task GetPlayableSpecializationsIndexAsync_Gets_PlayableSpecializationsIndex()
         {
             IPlayableSpecializationApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<PlayableSpecializationsIndex> result = await warcraftClient.GetPlayableSpecializationsIndexAsync("static-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetPlayableSpecializationAsync_Gets_PlayableSpecialization()
+        public async Task GetPlayableSpecializationAsync_Gets_PlayableSpecialization()
         {
             IPlayableSpecializationApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<PlayableSpecialization> result = await warcraftClient.GetPlayableSpecializationAsync(262, "static-us");
@@ -21,7 +22,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetPlayableSpecializationMediaAsync_Gets_PlayableSpecializationMedia()
+        public async Task GetPlayableSpecializationMediaAsync_Gets_PlayableSpecializationMedia()
         {
             IPlayableSpecializationApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<PlayableSpecializationMedia> result = await warcraftClient.GetPlayableSpecializationMediaAsync(262, "static-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PowerTypeApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PowerTypeApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class PowerTypeApiTests
     {
         [ResilientFact]
-        public async void GetPowerTypesIndexAsync_Gets_PowerTypesIndex()
+        public async Task GetPowerTypesIndexAsync_Gets_PowerTypesIndex()
         {
             IPowerTypeApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<PowerTypesIndex> result = await warcraftClient.GetPowerTypesIndexAsync("static-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetPowerTypeAsync_Gets_PowerType()
+        public async Task GetPowerTypeAsync_Gets_PowerType()
         {
             IPowerTypeApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<PowerType> result = await warcraftClient.GetPowerTypeAsync(0, "static-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/ProfessionApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/ProfessionApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class ProfessionApiTests
     {
         [ResilientFact]
-        public async void GetProfessionsIndexAsync_Gets_ProfessionsIndex()
+        public async Task GetProfessionsIndexAsync_Gets_ProfessionsIndex()
         {
             IProfessionApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<ProfessionsIndex> result = await warcraftClient.GetProfessionsIndexAsync("static-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetProfessionAsync_Gets_Profession()
+        public async Task GetProfessionAsync_Gets_Profession()
         {
             IProfessionApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<Profession> result = await warcraftClient.GetProfessionAsync(164, "static-us");
@@ -21,7 +22,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetProfessionMediaAsync_Gets_ProfessionMedia()
+        public async Task GetProfessionMediaAsync_Gets_ProfessionMedia()
         {
             IProfessionApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<ProfessionMedia> result = await warcraftClient.GetProfessionMediaAsync(164, "static-us");
@@ -29,7 +30,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetSkillTierAsync_Gets_SkillTier()
+        public async Task GetSkillTierAsync_Gets_SkillTier()
         {
             IProfessionApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<SkillTier> result = await warcraftClient.GetSkillTierAsync(164, 2477, "static-us");
@@ -37,7 +38,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetRecipeAsync_Gets_Recipe()
+        public async Task GetRecipeAsync_Gets_Recipe()
         {
             IProfessionApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<Recipe> result = await warcraftClient.GetRecipeAsync(1631, "static-us");
@@ -45,7 +46,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetRecipeMediaAsync_Gets_RecipeMedia()
+        public async Task GetRecipeMediaAsync_Gets_RecipeMedia()
         {
             IProfessionApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<RecipeMedia> result = await warcraftClient.GetRecipeMediaAsync(1631, "static-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PvpSeasonApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PvpSeasonApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class PvpSeasonApiTests
     {
         [ResilientFact]
-        public async void GetPvpSeasonsIndexAsync_Gets_PvpSeasonsIndex()
+        public async Task GetPvpSeasonsIndexAsync_Gets_PvpSeasonsIndex()
         {
             IPvpSeasonApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<PvpSeasonsIndex> result = await warcraftClient.GetPvpSeasonsIndexAsync("dynamic-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetPvpSeasonAsync_Gets_PvpSeason()
+        public async Task GetPvpSeasonAsync_Gets_PvpSeason()
         {
             IPvpSeasonApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<PvpSeason> result = await warcraftClient.GetPvpSeasonAsync(27, "dynamic-us");
@@ -21,7 +22,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetPvpLeaderboardsIndexAsync_Gets_PvpLeaderboardsIndex()
+        public async Task GetPvpLeaderboardsIndexAsync_Gets_PvpLeaderboardsIndex()
         {
             IPvpSeasonApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<PvpLeaderboardsIndex> result = await warcraftClient.GetPvpLeaderboardsIndexAsync(27, "dynamic-us");
@@ -29,7 +30,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetPvpLeaderboardAsync_Gets_PvpLeaderboard()
+        public async Task GetPvpLeaderboardAsync_Gets_PvpLeaderboard()
         {
             IPvpSeasonApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<PvpLeaderboard> result = await warcraftClient.GetPvpLeaderboardAsync(27, "3v3", "dynamic-us");
@@ -37,7 +38,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetPvpRewardsIndexAsync_Gets_PvpRewardsIndex()
+        public async Task GetPvpRewardsIndexAsync_Gets_PvpRewardsIndex()
         {
             IPvpSeasonApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<PvpRewardsIndex> result = await warcraftClient.GetPvpRewardsIndexAsync(27, "dynamic-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PvpTierApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PvpTierApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class PvpTierApiTests
     {
         [ResilientFact]
-        public async void GetPvpTiersIndexAsync_Gets_PvpTiersIndex()
+        public async Task GetPvpTiersIndexAsync_Gets_PvpTiersIndex()
         {
             IPvpTierApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<PvpTiersIndex> result = await warcraftClient.GetPvpTiersIndexAsync("static-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetPvpTierAsync_Gets_PvpTier()
+        public async Task GetPvpTierAsync_Gets_PvpTier()
         {
             IPvpTierApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<PvpTier> result = await warcraftClient.GetPvpTierAsync(1, "static-us");
@@ -21,7 +22,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetPvpTierMediaAsync_Gets_PvpTierMedia()
+        public async Task GetPvpTierMediaAsync_Gets_PvpTierMedia()
         {
             IPvpTierApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<PvpTierMedia> result = await warcraftClient.GetPvpTierMediaAsync(1, "static-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/QuestApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/QuestApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class QuestApiTests
     {
         [ResilientFact]
-        public async void GetQuestsIndexAsync_Gets_QuestsIndex()
+        public async Task GetQuestsIndexAsync_Gets_QuestsIndex()
         {
             IQuestApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<QuestsIndex> result = await warcraftClient.GetQuestsIndexAsync("static-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetQuestAsync_Gets_Quest()
+        public async Task GetQuestAsync_Gets_Quest()
         {
             IQuestApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<Quest> result = await warcraftClient.GetQuestAsync(2, "static-us");
@@ -21,7 +22,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetQuestCategoriesIndexAsync_Gets_QuestCategoriesIndex()
+        public async Task GetQuestCategoriesIndexAsync_Gets_QuestCategoriesIndex()
         {
             IQuestApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<QuestCategoriesIndex> result = await warcraftClient.GetQuestCategoriesIndexAsync("static-us");
@@ -29,7 +30,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetQuestCategoryAsync_Gets_QuestCategory()
+        public async Task GetQuestCategoryAsync_Gets_QuestCategory()
         {
             IQuestApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<QuestCategory> result = await warcraftClient.GetQuestCategoryAsync(1, "static-us");
@@ -37,7 +38,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetQuestAreasIndexAsync_Gets_QuestAreasIndex()
+        public async Task GetQuestAreasIndexAsync_Gets_QuestAreasIndex()
         {
             IQuestApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<QuestAreasIndex> result = await warcraftClient.GetQuestAreasIndexAsync("static-us");
@@ -45,7 +46,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetQuestAreaAsync_Gets_QuestArea()
+        public async Task GetQuestAreaAsync_Gets_QuestArea()
         {
             IQuestApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<QuestArea> result = await warcraftClient.GetQuestAreaAsync(1, "static-us");
@@ -53,7 +54,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetQuestTypesIndexAsync_Gets_QuestTypesIndex()
+        public async Task GetQuestTypesIndexAsync_Gets_QuestTypesIndex()
         {
             IQuestApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<QuestTypesIndex> result = await warcraftClient.GetQuestTypesIndexAsync("static-us");
@@ -61,7 +62,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetQuestTypeAsync_Gets_QuestType()
+        public async Task GetQuestTypeAsync_Gets_QuestType()
         {
             IQuestApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<QuestType> result = await warcraftClient.GetQuestTypeAsync(1, "static-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/RealmApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/RealmApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class RealmApiTests
     {
         [ResilientFact]
-        public async void GetPlayableRacesIndexAsync_Gets_PlayableRacesIndex()
+        public async Task GetPlayableRacesIndexAsync_Gets_PlayableRacesIndex()
         {
             IRealmApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<RealmsIndex> result = await warcraftClient.GetRealmsIndexAsync("dynamic-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetRealmAsync_Gets_Realm()
+        public async Task GetRealmAsync_Gets_Realm()
         {
             IRealmApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<Realm> result = await warcraftClient.GetRealmAsync("tichondrius", "dynamic-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/RegionApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/RegionApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class RegionApiTests
     {
         [ResilientFact]
-        public async void GetRegionsIndexAsync_Gets_RegionsIndex()
+        public async Task GetRegionsIndexAsync_Gets_RegionsIndex()
         {
             IRegionApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<RegionsIndex> result = await warcraftClient.GetRegionsIndexAsync("dynamic-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetRegionAsync_Gets_Region()
+        public async Task GetRegionAsync_Gets_Region()
         {
             IRegionApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<RegionData> result = await warcraftClient.GetRegionAsync(1, "dynamic-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/ReputationsApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/ReputationsApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class ReputationFactionApiTests
     {
         [ResilientFact]
-        public async void GetReputationFactionsIndexAsync_Gets_ReputationFactionsIndex()
+        public async Task GetReputationFactionsIndexAsync_Gets_ReputationFactionsIndex()
         {
             IReputationsApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<ReputationFactionsIndex> result = await warcraftClient.GetReputationFactionsIndexAsync("static-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetReputationFactionAsync_Gets_ReputationFaction()
+        public async Task GetReputationFactionAsync_Gets_ReputationFaction()
         {
             IReputationsApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<ReputationFaction> result = await warcraftClient.GetReputationFactionAsync(21, "static-us");
@@ -21,7 +22,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetReputationTiersIndexAsync_Gets_ReputationTiersIndex()
+        public async Task GetReputationTiersIndexAsync_Gets_ReputationTiersIndex()
         {
             IReputationsApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<ReputationTiersIndex> result = await warcraftClient.GetReputationTiersIndexAsync("static-us");
@@ -29,7 +30,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetReputationTiersAsync_Gets_ReputationTiers()
+        public async Task GetReputationTiersAsync_Gets_ReputationTiers()
         {
             IReputationsApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<ReputationTiers> result = await warcraftClient.GetReputationTiersAsync(2, "static-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/SpellApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/SpellApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class SpellApiTests
     {
         [ResilientFact]
-        public async void GetSpellAsync_Gets_Spell()
+        public async Task GetSpellAsync_Gets_Spell()
         {
             ISpellApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<Spell> result = await warcraftClient.GetSpellAsync(196607, "static-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetSpellMediaAsync_Gets_SpellMedia()
+        public async Task GetSpellMediaAsync_Gets_SpellMedia()
         {
             ISpellApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<SpellMedia> result = await warcraftClient.GetSpellMediaAsync(196607, "static-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/TalentApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/TalentApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class TalentApiTests
     {
         [ResilientFact]
-        public async void GetTalentsIndexAsync_Gets_TalentsIndex()
+        public async Task GetTalentsIndexAsync_Gets_TalentsIndex()
         {
             ITalentApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<TalentsIndex> result = await warcraftClient.GetTalentsIndexAsync("static-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetTalentAsync_Gets_Talent()
+        public async Task GetTalentAsync_Gets_Talent()
         {
             ITalentApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<Talent> result = await warcraftClient.GetTalentAsync(23106, "static-us");
@@ -21,7 +22,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetPvpTalentsIndexAsync_Gets_PvpTalentsIndex()
+        public async Task GetPvpTalentsIndexAsync_Gets_PvpTalentsIndex()
         {
             ITalentApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<PvpTalentsIndex> result = await warcraftClient.GetPvpTalentsIndexAsync("static-us");
@@ -29,7 +30,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetPvpTalentAsync_Gets_PvpTalent()
+        public async Task GetPvpTalentAsync_Gets_PvpTalent()
         {
             ITalentApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<PvpTalent> result = await warcraftClient.GetPvpTalentAsync(11, "static-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/TitleApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/TitleApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class TitleApiTests
     {
         [ResilientFact]
-        public async void GetTitlesIndexAsync_Gets_TitlesIndex()
+        public async Task GetTitlesIndexAsync_Gets_TitlesIndex()
         {
             ITitleApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<TitlesIndex> result = await warcraftClient.GetTitlesIndexAsync("static-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
-        public async void GetTitleAsync_Gets_Title()
+        public async Task GetTitleAsync_Gets_Title()
         {
             ITitleApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<Title> result = await warcraftClient.GetTitleAsync(1, "static-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/WowTokenApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/WowTokenApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
     public class WowTokenApiTests
     {
         [ResilientFact]
-        public async void GetWowTokenIndexAsync_Gets_WowTokenIndex()
+        public async Task GetWowTokenIndexAsync_Gets_WowTokenIndex()
         {
             IWowTokenApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<WowTokenIndex> result = await warcraftClient.GetWowTokenIndexAsync("dynamic-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterAchievementsApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterAchievementsApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
 {
     public class CharacterAchievementsApiTests
     {
         [ResilientFact]
-        public async void GetCharacterAchievementsSummaryAsync_Gets_CharacterAchievementsSummary()
+        public async Task GetCharacterAchievementsSummaryAsync_Gets_CharacterAchievementsSummary()
         {
             ICharacterAchievementsApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CharacterAchievementsSummary> result = await warcraftClient.GetCharacterAchievementsSummaryAsync("norgannon", "drinian", "profile-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
         }
 
         [ResilientFact]
-        public async void GetCharacterAchievementStatisticsAsync_Gets_CharacterAchievementStatistics()
+        public async Task GetCharacterAchievementStatisticsAsync_Gets_CharacterAchievementStatistics()
         {
             ICharacterAchievementsApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CharacterAchievementStatistics> result = await warcraftClient.GetCharacterAchievementStatisticsAsync("norgannon", "drinian", "profile-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterAppearanceApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterAppearanceApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
 {
     public class CharacterAppearanceApiTests
     {
         [ResilientFact]
-        public async void GetCharacterAppearanceSummaryAsync_Gets_CharacterAppearanceSummary()
+        public async Task GetCharacterAppearanceSummaryAsync_Gets_CharacterAppearanceSummary()
         {
             ICharacterAppearanceApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CharacterAppearanceSummary> result = await warcraftClient.GetCharacterAppearanceSummaryAsync("norgannon", "drinian", "profile-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterCollectionsApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterCollectionsApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
 {
     public class CharacterCollectionsApiTests
     {
         [ResilientFact]
-        public async void GetCharacterCollectionsIndexAsync_Gets_CharacterCollections()
+        public async Task GetCharacterCollectionsIndexAsync_Gets_CharacterCollections()
         {
             ICharacterCollectionsApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CharacterCollectionsIndex> result = await warcraftClient.GetCharacterCollectionsIndexAsync("norgannon", "drinian", "profile-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
         }
 
         [ResilientFact]
-        public async void GetCharacterMountsCollectionSummaryAsync_Gets_CharacterMountsSummary()
+        public async Task GetCharacterMountsCollectionSummaryAsync_Gets_CharacterMountsSummary()
         {
             ICharacterCollectionsApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CharacterMountsCollectionSummary> result = await warcraftClient.GetCharacterMountsCollectionSummaryAsync("norgannon", "drinian", "profile-us");
@@ -21,7 +22,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
         }
 
         [ResilientFact]
-        public async void GetCharacterPetsCollectionSummaryAsync_Gets_CharacterPetsSummary()
+        public async Task GetCharacterPetsCollectionSummaryAsync_Gets_CharacterPetsSummary()
         {
             ICharacterCollectionsApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CharacterPetsCollectionSummary> result = await warcraftClient.GetCharacterPetsCollectionSummaryAsync("norgannon", "drinian", "profile-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterEncountersApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterEncountersApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
 {
     public class CharacterEncountersApiTests
     {
         [ResilientFact]
-        public async void GetCharacterEncountersSummaryAsync_Gets_CharacterEncountersSummary()
+        public async Task GetCharacterEncountersSummaryAsync_Gets_CharacterEncountersSummary()
         {
             ICharacterEncountersApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CharacterEncountersSummary> result = await warcraftClient.GetCharacterEncountersSummaryAsync("norgannon", "drinian", "profile-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
         }
 
         [ResilientFact]
-        public async void GetCharacterDungeonsAsync_Gets_CharacterDungeons()
+        public async Task GetCharacterDungeonsAsync_Gets_CharacterDungeons()
         {
             ICharacterEncountersApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CharacterDungeons> result = await warcraftClient.GetCharacterDungeonsAsync("norgannon", "drinian", "profile-us");
@@ -21,7 +22,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
         }
 
         [ResilientFact]
-        public async void GetCharacterRaidsAsync_Gets_CharacterRaids()
+        public async Task GetCharacterRaidsAsync_Gets_CharacterRaids()
         {
             ICharacterEncountersApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CharacterRaids> result = await warcraftClient.GetCharacterRaidsAsync("norgannon", "drinian", "profile-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterEquipmentApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterEquipmentApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
 {
     public class CharacterEquipmentApiTests
     {
         [ResilientFact]
-        public async void GetCharacterEquipmentSummaryAsync_Gets_CharacterEquipmentSummary()
+        public async Task GetCharacterEquipmentSummaryAsync_Gets_CharacterEquipmentSummary()
         {
             ICharacterEquipmentApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CharacterEquipmentSummary> result = await warcraftClient.GetCharacterEquipmentSummaryAsync("norgannon", "drinian", "profile-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterHunterPetsApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterHunterPetsApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
 {
     public class CharacterHunterPetsApiTests
     {
         [ResilientFact]
-        public async void GetCharacterHunterPetsSummaryAsync_Gets_CharacterHunterPetsSummary()
+        public async Task GetCharacterHunterPetsSummaryAsync_Gets_CharacterHunterPetsSummary()
         {
             ICharacterHunterPetsApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CharacterHunterPetsSummary> result = await warcraftClient.GetCharacterHunterPetsSummaryAsync("norgannon", "anradin", "profile-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterMediaApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterMediaApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
 {
     public class CharacterMediaApiTests
     {
         [ResilientFact]
-        public async void GetCharacterMediaSummaryAsync_Gets_CharacterMediaSummary()
+        public async Task GetCharacterMediaSummaryAsync_Gets_CharacterMediaSummary()
         {
             ICharacterMediaApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CharacterMediaSummary> result = await warcraftClient.GetCharacterMediaSummaryAsync("norgannon", "drinian", "profile-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterMythicKeystoneProfileApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterMythicKeystoneProfileApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
 {
     public class CharacterMythicKeystoneProfileApiTests
     {
         [ResilientFact]
-        public async void GetCharacterMythicKeystoneProfileIndexAsync_Gets_CharacterMythicKeystoneProfileIndex()
+        public async Task GetCharacterMythicKeystoneProfileIndexAsync_Gets_CharacterMythicKeystoneProfileIndex()
         {
             ICharacterMythicKeystoneProfileApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CharacterMythicKeystoneProfileIndex> result = await warcraftClient.GetCharacterMythicKeystoneProfileIndexAsync("zuljin", "volladin", "profile-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
         }
 
         [ResilientFact]
-        public async void GetCharacterMythicKeystoneSeasonDetailsAsync_Gets_CharacterMythicKeystoneSeasonDetails()
+        public async Task GetCharacterMythicKeystoneSeasonDetailsAsync_Gets_CharacterMythicKeystoneSeasonDetails()
         {
             ICharacterMythicKeystoneProfileApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CharacterMythicKeystoneSeasonDetails> result = await warcraftClient.GetCharacterMythicKeystoneSeasonDetailsAsync("zuljin", "volladin", 1, "profile-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterProfessionsApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterProfessionsApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
 {
     public class CharacterProfessionsApiTests
     {
         [ResilientFact]
-        public async void GetCharacterProfessionsSummaryAsync_Gets_CharacterProfessionsSummary()
+        public async Task GetCharacterProfessionsSummaryAsync_Gets_CharacterProfessionsSummary()
         {
             ICharacterProfessionsApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CharacterProfessionsSummary> result = await warcraftClient.GetCharacterProfessionsSummaryAsync("norgannon", "drinian", "profile-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterProfileApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterProfileApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
 {
     public class CharacterProfileApiTests
     {
         [ResilientFact]
-        public async void GetCharacterProfileSummaryAsync_Gets_CharacterProfileSummary()
+        public async Task GetCharacterProfileSummaryAsync_Gets_CharacterProfileSummary()
         {
             ICharacterProfileApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CharacterProfileSummary> result = await warcraftClient.GetCharacterProfileSummaryAsync("norgannon", "drinian", "profile-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
         }
 
         [ResilientFact]
-        public async void GetCharacterStatusAsync_Gets_CharacterStatus()
+        public async Task GetCharacterStatusAsync_Gets_CharacterStatus()
         {
             ICharacterProfileApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CharacterStatus> result = await warcraftClient.GetCharacterStatusAsync("norgannon", "drinian", "profile-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterPvpApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterPvpApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
 {
     public class CharacterPvpApiTests
     {
         [ResilientFact]
-        public async void GetCharacterPvpBracketStatisticsAsync_Gets_PvpBracketStatistics()
+        public async Task GetCharacterPvpBracketStatisticsAsync_Gets_PvpBracketStatistics()
         {
             ICharacterPvpApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CharacterPvpBracketStatistics> result = await warcraftClient.GetCharacterPvpBracketStatisticsAsync("malganis", "zenli", "3v3", "profile-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
         }
 
         [ResilientFact]
-        public async void GetCharacterPvpSummaryAsync_Gets_CharacterPvpSummary()
+        public async Task GetCharacterPvpSummaryAsync_Gets_CharacterPvpSummary()
         {
             ICharacterPvpApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CharacterPvpSummary> result = await warcraftClient.GetCharacterPvpSummaryAsync("malganis", "zenli", "profile-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterQuestsApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterQuestsApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
 {
     public class CharacterQuestsApiTests
     {
         [ResilientFact]
-        public async void GetCharacterQuestsAsync_Gets_CharacterQuests()
+        public async Task GetCharacterQuestsAsync_Gets_CharacterQuests()
         {
             ICharacterQuestsApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CharacterQuests> result = await warcraftClient.GetCharacterQuestsAsync("norgannon", "drinian", "profile-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
         }
 
         [ResilientFact]
-        public async void GetCharacterCompletedQuestsAsync_Gets_CharacterCompletedQuests()
+        public async Task GetCharacterCompletedQuestsAsync_Gets_CharacterCompletedQuests()
         {
             ICharacterQuestsApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CharacterCompletedQuests> result = await warcraftClient.GetCharacterCompletedQuestsAsync("norgannon", "drinian", "profile-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterReputationsApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterReputationsApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
 {
     public class CharacterReputationsApiTests
     {
         [ResilientFact]
-        public async void GetCharacterReputationsSummaryAsync_Gets_CharacterReputationsSummary()
+        public async Task GetCharacterReputationsSummaryAsync_Gets_CharacterReputationsSummary()
         {
             ICharacterReputationsApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CharacterReputationsSummary> result = await warcraftClient.GetCharacterReputationsSummaryAsync("norgannon", "drinian", "profile-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterSpecializationsApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterSpecializationsApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
 {
     public class CharacterSpecializationsApiTests
     {
         [ResilientFact]
-        public async void GetCharacterSpecializationsSummaryAsync_Gets_CharacterSpecializationsSummary()
+        public async Task GetCharacterSpecializationsSummaryAsync_Gets_CharacterSpecializationsSummary()
         {
             ICharacterSpecializationsApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CharacterSpecializationsSummary> result = await warcraftClient.GetCharacterSpecializationsSummaryAsync("norgannon", "drinian", "profile-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterStatisticsApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterStatisticsApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
 {
     public class CharacterStatisticsApiTests
     {
         [ResilientFact]
-        public async void GetCharacterStatisticsSummaryAsync_Gets_CharacterStatisticsSummary()
+        public async Task GetCharacterStatisticsSummaryAsync_Gets_CharacterStatisticsSummary()
         {
             ICharacterStatisticsApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CharacterStatisticsSummary> result = await warcraftClient.GetCharacterStatisticsSummaryAsync("norgannon", "drinian", "profile-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterTitlesApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterTitlesApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
 {
     public class CharacterTitlesApiTests
     {
         [ResilientFact]
-        public async void GetCharacterTitlesSummaryAsync_Gets_CharacterTitlesSummary()
+        public async Task GetCharacterTitlesSummaryAsync_Gets_CharacterTitlesSummary()
         {
             ICharacterTitlesApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<CharacterTitlesSummary> result = await warcraftClient.GetCharacterTitlesSummaryAsync("norgannon", "drinian", "profile-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/GuildApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/GuildApiTests.cs
@@ -1,11 +1,12 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
 {
     public class GuildApiTests
     {
         [ResilientFact]
-        public async void GetGuildAsync_Gets_Guild()
+        public async Task GetGuildAsync_Gets_Guild()
         {
             IGuildApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<Guild> result = await warcraftClient.GetGuildAsync("deathwing", "enigma", "profile-us");
@@ -13,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
         }
 
         [ResilientFact]
-        public async void GetGuildActivityAsync_Gets_GuildActivity()
+        public async Task GetGuildActivityAsync_Gets_GuildActivity()
         {
             IGuildApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<GuildActivity> result = await warcraftClient.GetGuildActivityAsync("deathwing", "enigma", "profile-us");
@@ -21,7 +22,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
         }
 
         [ResilientFact]
-        public async void GetGuildAchievementsAsync_Gets_GuildAchievements()
+        public async Task GetGuildAchievementsAsync_Gets_GuildAchievements()
         {
             IGuildApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<GuildAchievements> result = await warcraftClient.GetGuildAchievementsAsync("deathwing", "enigma", "profile-us");
@@ -29,7 +30,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.ProfileApi
         }
 
         [ResilientFact]
-        public async void GetGuildRosterAsync_Gets_GuildRoster()
+        public async Task GetGuildRosterAsync_Gets_GuildRoster()
         {
             IGuildApi warcraftClient = ClientFactory.BuildClient();
             RequestResult<GuildRoster> result = await warcraftClient.GetGuildRosterAsync("deathwing", "enigma", "profile-us");

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/WarcraftClientTestsErrorConditions.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/WarcraftClientTestsErrorConditions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests
     public class WarcraftClientTestsErrorConditions
     {
         [ResilientFact]
-        public async void InvalidIdProducesNotFoundError()
+        public async Task InvalidIdProducesNotFoundError()
         {
             IWarcraftClient warcraftClient = ClientFactory.BuildClient();
 
@@ -18,7 +19,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests
         }
 
         [ResilientFact]
-        public async void InvalidTokenThrowsHttpRequestException()
+        public async Task InvalidTokenThrowsHttpRequestException()
         {
             IWarcraftClient warcraftClient = ClientFactory.BuildClient();
 

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/AchievementApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/AchievementApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class AchievementApiTests
     {
         [Fact]
-        public async void GetAchievementCategoriesIndexAsync_Gets_AchievementCategoriesIndex()
+        public async Task GetAchievementCategoriesIndexAsync_Gets_AchievementCategoriesIndex()
         {
             IAchievementApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/achievement-category/index?namespace=static-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetAchievementCategoryAsync_Gets_AchievementCategory()
+        public async Task GetAchievementCategoryAsync_Gets_AchievementCategory()
         {
             IAchievementApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/achievement-category/81?namespace=static-us&locale=en_US",
@@ -28,7 +29,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetAchievementsIndexAsync_Gets_AchievementsIndex()
+        public async Task GetAchievementsIndexAsync_Gets_AchievementsIndex()
         {
             IAchievementApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/achievement/index?namespace=static-us&locale=en_US",
@@ -39,7 +40,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetAchievementAsync_Gets_Achievement()
+        public async Task GetAchievementAsync_Gets_Achievement()
         {
             IAchievementApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/achievement/6?namespace=static-us&locale=en_US",
@@ -50,7 +51,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetAchievementMediaAsync_Gets_AchievementMedia()
+        public async Task GetAchievementMediaAsync_Gets_AchievementMedia()
         {
             IAchievementApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/media/achievement/6?namespace=static-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/AuctionHouseApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/AuctionHouseApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class AuctionHouseApiTests
     {
         [Fact]
-        public async void GetAuctionsAsync_Gets_Auctions()
+        public async Task GetAuctionsAsync_Gets_Auctions()
         {
             IAuctionHouseApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/connected-realm/4/auctions?namespace=dynamic-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/AzeriteEssenceApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/AzeriteEssenceApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class AzeriteEssenceApiTests
     {
         [Fact]
-        public async void GetAzeriteEssencesIndexAsync_Gets_AzeriteEssencesIndex()
+        public async Task GetAzeriteEssencesIndexAsync_Gets_AzeriteEssencesIndex()
         {
             IAzeriteEssenceApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/azerite-essence/index?namespace=static-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetAzeriteEssenceAsync_Gets_AzeriteEssence()
+        public async Task GetAzeriteEssenceAsync_Gets_AzeriteEssence()
         {
             IAzeriteEssenceApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/azerite-essence/2?namespace=static-us&locale=en_US",
@@ -28,7 +29,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetAzeriteEssenceMediaAsync_Gets_AzeriteEssenceMedia()
+        public async Task GetAzeriteEssenceMediaAsync_Gets_AzeriteEssenceMedia()
         {
             IAzeriteEssenceApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/media/azerite-essence/2?namespace=static-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/ConnectedRealmApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/ConnectedRealmApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class ConnectedRealmApiTests
     {
         [Fact]
-        public async void GetPlayableRacesIndexAsync_Gets_PlayableRacesIndex()
+        public async Task GetPlayableRacesIndexAsync_Gets_PlayableRacesIndex()
         {
             IConnectedRealmApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/connected-realm/index?namespace=dynamic-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetRealmAsync_Gets_Realm()
+        public async Task GetRealmAsync_Gets_Realm()
         {
             IConnectedRealmApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/connected-realm/11?namespace=dynamic-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/CreatureApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/CreatureApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class CreatureApiTests
     {
         [Fact]
-        public async void GetCreatureFamiliesIndexAsync_Gets_CreatureFamiliesIndex()
+        public async Task GetCreatureFamiliesIndexAsync_Gets_CreatureFamiliesIndex()
         {
             ICreatureApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/creature-family/index?namespace=static-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetCreatureFamilyAsync_Gets_CreatureFamily()
+        public async Task GetCreatureFamilyAsync_Gets_CreatureFamily()
         {
             ICreatureApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/creature-family/1?namespace=static-us&locale=en_US",
@@ -28,7 +29,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetCreatureTypesIndexAsync_Gets_CreatureTypesIndex()
+        public async Task GetCreatureTypesIndexAsync_Gets_CreatureTypesIndex()
         {
             ICreatureApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/creature-type/index?namespace=static-us&locale=en_US",
@@ -39,7 +40,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetCreatureTypeAsync_Gets_CreatureType()
+        public async Task GetCreatureTypeAsync_Gets_CreatureType()
         {
             ICreatureApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/creature-type/1?namespace=static-us&locale=en_US",
@@ -50,7 +51,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetCreatureAsync_Gets_Creature()
+        public async Task GetCreatureAsync_Gets_Creature()
         {
             ICreatureApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/creature/42722?namespace=static-us&locale=en_US",
@@ -61,7 +62,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetCreatureDisplayMediaAsync_Gets_CreatureDisplayMedia()
+        public async Task GetCreatureDisplayMediaAsync_Gets_CreatureDisplayMedia()
         {
             ICreatureApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/media/creature-display/30221?namespace=static-us&locale=en_US",
@@ -72,7 +73,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetCreatureFamilyMediaAsync_Gets_CreatureFamilyMedia()
+        public async Task GetCreatureFamilyMediaAsync_Gets_CreatureFamilyMedia()
         {
             ICreatureApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/media/creature-family/1?namespace=static-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/GuildCrestApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/GuildCrestApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class GuildCrestApiTests
     {
         [Fact]
-        public async void GetGuildCrestComponentsIndexAsync_Gets_GuildCrestComponentsIndex()
+        public async Task GetGuildCrestComponentsIndexAsync_Gets_GuildCrestComponentsIndex()
         {
             IGuildCrestApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/guild-crest/index?namespace=static-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetGuildCrestBorderMediaAsync_Gets_GuildCrestBorderMedia()
+        public async Task GetGuildCrestBorderMediaAsync_Gets_GuildCrestBorderMedia()
         {
             IGuildCrestApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/media/guild-crest/border/0?namespace=static-us&locale=en_US",
@@ -28,7 +29,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetGuildCrestEmblemMediaAsync_Gets_GuildCrestEmblemMedia()
+        public async Task GetGuildCrestEmblemMediaAsync_Gets_GuildCrestEmblemMedia()
         {
             IGuildCrestApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/media/guild-crest/emblem/0?namespace=static-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/ItemApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/ItemApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class ItemApiTests
     {
         [Fact]
-        public async void GetItemClassesIndexAsync_Gets_ItemClassesIndex()
+        public async Task GetItemClassesIndexAsync_Gets_ItemClassesIndex()
         {
             IItemApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/item-class/index?namespace=static-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetItemClassAsync_Gets_ItemClass()
+        public async Task GetItemClassAsync_Gets_ItemClass()
         {
             IItemApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/item-class/0?namespace=static-us&locale=en_US",
@@ -28,7 +29,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetItemSetsIndexAsync_Gets_ItemSetsIndex()
+        public async Task GetItemSetsIndexAsync_Gets_ItemSetsIndex()
         {
             IItemApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/item-set/index?namespace=static-us&locale=en_US",
@@ -39,7 +40,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetItemSetAsync_Gets_ItemSet()
+        public async Task GetItemSetAsync_Gets_ItemSet()
         {
             IItemApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/item-set/1?namespace=static-us&locale=en_US",
@@ -50,7 +51,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetItemSubclassAsync_Gets_ItemSubclass()
+        public async Task GetItemSubclassAsync_Gets_ItemSubclass()
         {
             IItemApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/item-class/0/item-subclass/0?namespace=static-us&locale=en_US",
@@ -61,7 +62,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetItemAsync_Gets_Item()
+        public async Task GetItemAsync_Gets_Item()
         {
             IItemApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/item/19019?namespace=static-us&locale=en_US",
@@ -72,7 +73,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetItemMediaAsync_Gets_Item()
+        public async Task GetItemMediaAsync_Gets_Item()
         {
             IItemApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/media/item/19019?namespace=static-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/JournalApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/JournalApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class JournalApiTests
     {
         [Fact]
-        public async void GetJournalExpansionsIndexAsync_Gets_JournalExpansions()
+        public async Task GetJournalExpansionsIndexAsync_Gets_JournalExpansions()
         {
             IJournalApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/journal-expansion/index?namespace=static-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetJournalExpansionAsync_Gets_JournalExpansion()
+        public async Task GetJournalExpansionAsync_Gets_JournalExpansion()
         {
             IJournalApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/journal-expansion/68?namespace=static-us&locale=en_US",
@@ -28,7 +29,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetJournalEncountersIndexAsync_Gets_JournalEncounters()
+        public async Task GetJournalEncountersIndexAsync_Gets_JournalEncounters()
         {
             IJournalApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/journal-encounter/index?namespace=static-us&locale=en_US",
@@ -39,7 +40,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetJournalEncounterAsync_Gets_Encounter()
+        public async Task GetJournalEncounterAsync_Gets_Encounter()
         {
             IJournalApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/journal-encounter/89?namespace=static-us&locale=en_US",
@@ -50,7 +51,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetJournalInstancesIndexAsync_Gets_JournalInstances()
+        public async Task GetJournalInstancesIndexAsync_Gets_JournalInstances()
         {
             IJournalApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/journal-instance/index?namespace=static-us&locale=en_US",
@@ -61,7 +62,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetJournalInstanceAsync_Gets_Instance()
+        public async Task GetJournalInstanceAsync_Gets_Instance()
         {
             IJournalApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/journal-instance/63?namespace=static-us&locale=en_US",
@@ -72,7 +73,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetJournalInstanceMediaAsync_Gets_InstanceMedia()
+        public async Task GetJournalInstanceMediaAsync_Gets_InstanceMedia()
         {
             IJournalApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/media/journal-instance/63?namespace=static-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/MountApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/MountApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class MountApiTests
     {
         [Fact]
-        public async void GetMountsIndexAsync_Gets_MountsIndex()
+        public async Task GetMountsIndexAsync_Gets_MountsIndex()
         {
             IMountApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/mount/index?namespace=static-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetMountAsync_Gets_Mount()
+        public async Task GetMountAsync_Gets_Mount()
         {
             IMountApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/mount/6?namespace=static-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/MythicKeystoneAffixApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/MythicKeystoneAffixApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class MythicKeystoneAffixApiTests
     {
         [Fact]
-        public async void GetMythicKeystoneLeaderboardsIndexAsync_Gets_MythicKeystoneLeaderboardsIndex()
+        public async Task GetMythicKeystoneLeaderboardsIndexAsync_Gets_MythicKeystoneLeaderboardsIndex()
         {
             IMythicKeystoneAffixApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/keystone-affix/index?namespace=static-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetMythicKeystoneAffixAsync_Gets_MythicKeystoneAffix()
+        public async Task GetMythicKeystoneAffixAsync_Gets_MythicKeystoneAffix()
         {
             IMythicKeystoneAffixApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/keystone-affix/1?namespace=static-us&locale=en_US",
@@ -28,7 +29,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetMythicKeystoneAffixMediaAsync_Gets_MythicKeystoneAffixMedia()
+        public async Task GetMythicKeystoneAffixMediaAsync_Gets_MythicKeystoneAffixMedia()
         {
             IMythicKeystoneAffixApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/media/keystone-affix/1?namespace=static-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/MythicKeystoneDungeonApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/MythicKeystoneDungeonApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class MythicKeystoneDungeonApiTests
     {
         [Fact]
-        public async void GetMythicKeystoneDungeonsIndexAsync_Gets_MythicKeystoneDungeonsIndex()
+        public async Task GetMythicKeystoneDungeonsIndexAsync_Gets_MythicKeystoneDungeonsIndex()
         {
             IMythicKeystoneDungeonApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/mythic-keystone/dungeon/index?namespace=dynamic-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetMythicKeystoneDungeonAsync_Gets_MythicKeystoneDungeon()
+        public async Task GetMythicKeystoneDungeonAsync_Gets_MythicKeystoneDungeon()
         {
             IMythicKeystoneDungeonApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/mythic-keystone/dungeon/353?namespace=dynamic-us&locale=en_US",
@@ -28,7 +29,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetMythicKeystoneIndexAsync_Gets_MythicKeystoneIndex()
+        public async Task GetMythicKeystoneIndexAsync_Gets_MythicKeystoneIndex()
         {
             IMythicKeystoneDungeonApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/mythic-keystone/index?namespace=dynamic-us&locale=en_US",
@@ -39,7 +40,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetMythicKeystonePeriodsIndexAsync_Gets_MythicKeystonePeriodsIndex()
+        public async Task GetMythicKeystonePeriodsIndexAsync_Gets_MythicKeystonePeriodsIndex()
         {
             IMythicKeystoneDungeonApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/mythic-keystone/period/index?namespace=dynamic-us&locale=en_US",
@@ -50,7 +51,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetMythicKeystonePeriodAsync_Gets_MythicKeystonePeriod()
+        public async Task GetMythicKeystonePeriodAsync_Gets_MythicKeystonePeriod()
         {
             IMythicKeystoneDungeonApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/mythic-keystone/period/641?namespace=dynamic-us&locale=en_US",
@@ -61,7 +62,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetMythicKeystoneSeasonsIndexAsync_Gets_MythicKeystoneSeasonsIndex()
+        public async Task GetMythicKeystoneSeasonsIndexAsync_Gets_MythicKeystoneSeasonsIndex()
         {
             IMythicKeystoneDungeonApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/mythic-keystone/season/index?namespace=dynamic-us&locale=en_US",
@@ -72,7 +73,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetMythicKeystoneSeasonAsync_Gets_MythicKeystoneSeason()
+        public async Task GetMythicKeystoneSeasonAsync_Gets_MythicKeystoneSeason()
         {
             IMythicKeystoneDungeonApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/mythic-keystone/season/1?namespace=dynamic-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/MythicKeystoneLeaderboardApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/MythicKeystoneLeaderboardApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class MythicKeystoneLeaderboardApiTests
     {
         [Fact]
-        public async void GetMythicKeystoneLeaderboardsIndexAsync_Gets_MythicKeystoneLeaderboardsIndex()
+        public async Task GetMythicKeystoneLeaderboardsIndexAsync_Gets_MythicKeystoneLeaderboardsIndex()
         {
             IMythicKeystoneLeaderboardApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/connected-realm/11/mythic-leaderboard/index?namespace=dynamic-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetMythicKeystoneLeaderboard_Gets_MythicKeystoneLeaderboard()
+        public async Task GetMythicKeystoneLeaderboard_Gets_MythicKeystoneLeaderboard()
         {
             IMythicKeystoneLeaderboardApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/connected-realm/11/mythic-leaderboard/197/period/641?namespace=dynamic-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/MythicRaidLeaderboardApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/MythicRaidLeaderboardApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class MythicRaidLeaderboardApiTests
     {
         [Fact]
-        public async void GetMythicKeystoneLeaderboardsIndexAsync_Gets_MythicKeystoneLeaderboardsIndex()
+        public async Task GetMythicKeystoneLeaderboardsIndexAsync_Gets_MythicKeystoneLeaderboardsIndex()
         {
             IMythicRaidLeaderboardApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/leaderboard/hall-of-fame/uldir/alliance?namespace=dynamic-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/PetApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/PetApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class PetApiTests
     {
         [Fact]
-        public async void GetPetsIndexAsync_Gets_PetsIndex()
+        public async Task GetPetsIndexAsync_Gets_PetsIndex()
         {
             IPetApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/pet/index?namespace=static-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetPetAsync_Gets_Pet()
+        public async Task GetPetAsync_Gets_Pet()
         {
             IPetApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/pet/39?namespace=static-us&locale=en_US",
@@ -28,7 +29,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetPetAbilitiesIndexAsync_Gets_PetAbilitiesIndex()
+        public async Task GetPetAbilitiesIndexAsync_Gets_PetAbilitiesIndex()
         {
             IPetApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/pet-ability/index?namespace=static-us&locale=en_US",
@@ -39,7 +40,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetPetAbilityAsync_Gets_PetAbility()
+        public async Task GetPetAbilityAsync_Gets_PetAbility()
         {
             IPetApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/pet-ability/110?namespace=static-us&locale=en_US",
@@ -50,7 +51,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetPetAbilityMediaAsync_Gets_PetAbilityMedia()
+        public async Task GetPetAbilityMediaAsync_Gets_PetAbilityMedia()
         {
             IPetApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/media/pet-ability/110?namespace=static-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/PlayableClassApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/PlayableClassApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class PlayableClassApiTests
     {
         [Fact]
-        public async void GetPlayableClassesIndexAsync_Gets_PlayableClassesIndex()
+        public async Task GetPlayableClassesIndexAsync_Gets_PlayableClassesIndex()
         {
             IPlayableClassApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/playable-class/index?namespace=static-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetPlayableClassAsync_Gets_PlayableClass()
+        public async Task GetPlayableClassAsync_Gets_PlayableClass()
         {
             IPlayableClassApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/playable-class/7?namespace=static-us&locale=en_US",
@@ -28,7 +29,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetPlayableClassMediaAsync_Gets_PlayableClassMedia()
+        public async Task GetPlayableClassMediaAsync_Gets_PlayableClassMedia()
         {
             IPlayableClassApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/media/playable-class/7?namespace=static-us&locale=en_US",
@@ -39,7 +40,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetPvpTalentSlotsAsync_Gets_PvpTalentSlots()
+        public async Task GetPvpTalentSlotsAsync_Gets_PvpTalentSlots()
         {
             IPlayableClassApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/playable-class/7/pvp-talent-slots?namespace=static-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/PlayableRaceApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/PlayableRaceApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class PlayableRaceApiTests
     {
         [Fact]
-        public async void GetPlayableRacesIndexAsync_Gets_PlayableRacesIndex()
+        public async Task GetPlayableRacesIndexAsync_Gets_PlayableRacesIndex()
         {
             IPlayableRaceApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/playable-race/index?namespace=static-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetPlayableRaceAsync_Gets_PlayableRace()
+        public async Task GetPlayableRaceAsync_Gets_PlayableRace()
         {
             IPlayableRaceApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/playable-race/2?namespace=static-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/PlayableSpecializationApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/PlayableSpecializationApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class PlayableSpecializationApiTests
     {
         [Fact]
-        public async void GetPlayableSpecializationsIndexAsync_Gets_PlayableSpecializationsIndex()
+        public async Task GetPlayableSpecializationsIndexAsync_Gets_PlayableSpecializationsIndex()
         {
             IPlayableSpecializationApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/playable-specialization/index?namespace=static-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetPlayableSpecializationAsync_Gets_PlayableSpecialization()
+        public async Task GetPlayableSpecializationAsync_Gets_PlayableSpecialization()
         {
             IPlayableSpecializationApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/playable-specialization/262?namespace=static-us&locale=en_US",
@@ -28,7 +29,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetPlayableSpecializationMediaAsync_Gets_PlayableSpecializationMedia()
+        public async Task GetPlayableSpecializationMediaAsync_Gets_PlayableSpecializationMedia()
         {
             IPlayableSpecializationApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/media/playable-specialization/262?namespace=static-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/PowerTypeApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/PowerTypeApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class PowerTypeApiTests
     {
         [Fact]
-        public async void GetPowerTypesIndexAsync_Gets_PowerTypesIndex()
+        public async Task GetPowerTypesIndexAsync_Gets_PowerTypesIndex()
         {
             IPowerTypeApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/power-type/index?namespace=static-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetPowerTypeAsync_Gets_PowerType()
+        public async Task GetPowerTypeAsync_Gets_PowerType()
         {
             IPowerTypeApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/power-type/0?namespace=static-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/ProfessionApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/ProfessionApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class ProfessionApiTests
     {
         [Fact]
-        public async void GetProfessionsIndexAsync_Gets_ProfessionsIndex()
+        public async Task GetProfessionsIndexAsync_Gets_ProfessionsIndex()
         {
             IProfessionApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/profession/index?namespace=static-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetProfessionAsync_Gets_Profession()
+        public async Task GetProfessionAsync_Gets_Profession()
         {
             IProfessionApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/profession/164?namespace=static-us&locale=en_US",
@@ -28,7 +29,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetProfessionMediaAsync_Gets_ProfessionMedia()
+        public async Task GetProfessionMediaAsync_Gets_ProfessionMedia()
         {
             IProfessionApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/media/profession/164?namespace=static-us&locale=en_US",
@@ -39,7 +40,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetSkillTierAsync_Gets_SkillTier()
+        public async Task GetSkillTierAsync_Gets_SkillTier()
         {
             IProfessionApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/profession/164/skill-tier/2477?namespace=static-us&locale=en_US",
@@ -50,7 +51,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetRecipeAsync_Gets_Recipe()
+        public async Task GetRecipeAsync_Gets_Recipe()
         {
             IProfessionApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/recipe/1631?namespace=static-us&locale=en_US",
@@ -61,7 +62,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetRecipeMediaAsync_Gets_RecipeMedia()
+        public async Task GetRecipeMediaAsync_Gets_RecipeMedia()
         {
             IProfessionApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/media/recipe/1631?namespace=static-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/PvpSeasonApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/PvpSeasonApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class PvpSeasonApiTests
     {
         [Fact]
-        public async void GetPvpSeasonsIndexAsync_Gets_PvpSeasonsIndex()
+        public async Task GetPvpSeasonsIndexAsync_Gets_PvpSeasonsIndex()
         {
             IPvpSeasonApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/pvp-season/index?namespace=dynamic-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetPvpSeasonAsync_Gets_PvpSeason()
+        public async Task GetPvpSeasonAsync_Gets_PvpSeason()
         {
             IPvpSeasonApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/pvp-season/27?namespace=dynamic-us&locale=en_US",
@@ -28,7 +29,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetPvpLeaderboardsIndexAsync_Gets_PvpLeaderboardsIndex()
+        public async Task GetPvpLeaderboardsIndexAsync_Gets_PvpLeaderboardsIndex()
         {
             IPvpSeasonApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/pvp-season/27/pvp-leaderboard/index?namespace=dynamic-us&locale=en_US",
@@ -39,7 +40,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetPvpLeaderboardAsync_Gets_PvpLeaderboard()
+        public async Task GetPvpLeaderboardAsync_Gets_PvpLeaderboard()
         {
             IPvpSeasonApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/pvp-season/27/pvp-leaderboard/3v3?namespace=dynamic-us&locale=en_US",
@@ -50,7 +51,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetPvpRewardsIndexAsync_Gets_PvpRewardsIndex()
+        public async Task GetPvpRewardsIndexAsync_Gets_PvpRewardsIndex()
         {
             IPvpSeasonApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/pvp-season/27/pvp-reward/index?namespace=dynamic-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/PvpTierApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/PvpTierApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class PvpTierApiTests
     {
         [Fact]
-        public async void GetPvpTiersIndexAsync_Gets_PvpTiersIndex()
+        public async Task GetPvpTiersIndexAsync_Gets_PvpTiersIndex()
         {
             IPvpTierApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/pvp-tier/index?namespace=static-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetPvpTierAsync_Gets_PvpTier()
+        public async Task GetPvpTierAsync_Gets_PvpTier()
         {
             IPvpTierApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/pvp-tier/1?namespace=static-us&locale=en_US",
@@ -28,7 +29,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetPvpTierMediaAsync_Gets_PvpTierMedia()
+        public async Task GetPvpTierMediaAsync_Gets_PvpTierMedia()
         {
             IPvpTierApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/media/pvp-tier/1?namespace=static-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/QuestApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/QuestApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class QuestApiTests
     {
         [Fact]
-        public async void GetQuestsIndexAsync_Gets_QuestsIndex()
+        public async Task GetQuestsIndexAsync_Gets_QuestsIndex()
         {
             IQuestApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/quest/index?namespace=static-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetQuestAsync_Gets_Quest()
+        public async Task GetQuestAsync_Gets_Quest()
         {
             IQuestApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/quest/2?namespace=static-us&locale=en_US",
@@ -28,7 +29,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetQuestCategoriesIndexAsync_Gets_QuestCategoriesIndex()
+        public async Task GetQuestCategoriesIndexAsync_Gets_QuestCategoriesIndex()
         {
             IQuestApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/quest/category/index?namespace=static-us&locale=en_US",
@@ -39,7 +40,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetQuestCategoryAsync_Gets_QuestCategory()
+        public async Task GetQuestCategoryAsync_Gets_QuestCategory()
         {
             IQuestApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/quest/category/1?namespace=static-us&locale=en_US",
@@ -50,7 +51,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetQuestAreasIndexAsync_Gets_QuestAreasIndex()
+        public async Task GetQuestAreasIndexAsync_Gets_QuestAreasIndex()
         {
             IQuestApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/quest/area/index?namespace=static-us&locale=en_US",
@@ -61,7 +62,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetQuestAreaAsync_Gets_QuestArea()
+        public async Task GetQuestAreaAsync_Gets_QuestArea()
         {
             IQuestApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/quest/area/1?namespace=static-us&locale=en_US",
@@ -72,7 +73,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetQuestTypesIndexAsync_Gets_QuestTypesIndex()
+        public async Task GetQuestTypesIndexAsync_Gets_QuestTypesIndex()
         {
             IQuestApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/quest/type/index?namespace=static-us&locale=en_US",
@@ -83,7 +84,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetQuestTypeAsync_Gets_QuestType()
+        public async Task GetQuestTypeAsync_Gets_QuestType()
         {
             IQuestApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/quest/type/1?namespace=static-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/RealmApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/RealmApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class RealmApiTests
     {
         [Fact]
-        public async void GetPlayableRacesIndexAsync_Gets_PlayableRacesIndex()
+        public async Task GetPlayableRacesIndexAsync_Gets_PlayableRacesIndex()
         {
             IRealmApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/realm/index?namespace=dynamic-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetRealmAsync_Gets_Realm()
+        public async Task GetRealmAsync_Gets_Realm()
         {
             IRealmApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/realm/tichondrius?namespace=dynamic-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/RegionApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/RegionApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class RegionApiTests
     {
         [Fact]
-        public async void GetRegionsIndexAsync_Gets_RegionsIndex()
+        public async Task GetRegionsIndexAsync_Gets_RegionsIndex()
         {
             IRegionApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/region/index?namespace=dynamic-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetRegionAsync_Gets_Region()
+        public async Task GetRegionAsync_Gets_Region()
         {
             IRegionApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/region/1?namespace=dynamic-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/ReputationsApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/ReputationsApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class ReputationFactionApiTests
     {
         [Fact]
-        public async void GetReputationFactionsIndexAsync_Gets_ReputationFactionsIndex()
+        public async Task GetReputationFactionsIndexAsync_Gets_ReputationFactionsIndex()
         {
             IReputationsApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/reputation-faction/index?namespace=static-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetReputationFactionAsync_Gets_ReputationFaction()
+        public async Task GetReputationFactionAsync_Gets_ReputationFaction()
         {
             IReputationsApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/reputation-faction/21?namespace=static-us&locale=en_US",
@@ -28,7 +29,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetReputationTiersIndexAsync_Gets_ReputationTiersIndex()
+        public async Task GetReputationTiersIndexAsync_Gets_ReputationTiersIndex()
         {
             IReputationsApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/reputation-tiers/index?namespace=static-us&locale=en_US",
@@ -39,7 +40,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetReputationTiersAsync_Gets_ReputationTiers()
+        public async Task GetReputationTiersAsync_Gets_ReputationTiers()
         {
             IReputationsApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/reputation-tiers/2?namespace=static-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/SpellApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/SpellApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class SpellApiTests
     {
         [Fact]
-        public async void GetSpellAsync_Gets_Spell()
+        public async Task GetSpellAsync_Gets_Spell()
         {
             ISpellApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/spell/196607?namespace=static-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetSpellMediaAsync_Gets_SpellMedia()
+        public async Task GetSpellMediaAsync_Gets_SpellMedia()
         {
             ISpellApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/media/spell/196607?namespace=static-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/TalentApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/TalentApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class TalentApiTests
     {
         [Fact]
-        public async void GetTalentsIndexAsync_Gets_TalentsIndex()
+        public async Task GetTalentsIndexAsync_Gets_TalentsIndex()
         {
             ITalentApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/talent/index?namespace=static-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetTalentAsync_Gets_Talent()
+        public async Task GetTalentAsync_Gets_Talent()
         {
             ITalentApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/talent/23106?namespace=static-us&locale=en_US",
@@ -28,7 +29,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetPvpTalentsIndexAsync_Gets_PvpTalentsIndex()
+        public async Task GetPvpTalentsIndexAsync_Gets_PvpTalentsIndex()
         {
             ITalentApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/pvp-talent/index?namespace=static-us&locale=en_US",
@@ -39,7 +40,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetPvpTalentAsync_Gets_PvpTalent()
+        public async Task GetPvpTalentAsync_Gets_PvpTalent()
         {
             ITalentApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/pvp-talent/11?namespace=static-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/TitleApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/TitleApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class TitleApiTests
     {
         [Fact]
-        public async void GetTitlesIndexAsync_Gets_TitlesIndex()
+        public async Task GetTitlesIndexAsync_Gets_TitlesIndex()
         {
             ITitleApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/title/index?namespace=static-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
-        public async void GetTitleAsync_Gets_Title()
+        public async Task GetTitleAsync_Gets_Title()
         {
             ITitleApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/title/1?namespace=static-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/WowTokenApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/WowTokenApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.GameDataApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
     public class WowTokenApiTests
     {
         [Fact]
-        public async void GetWowTokenIndexAsync_Gets_WowTokenIndex()
+        public async Task GetWowTokenIndexAsync_Gets_WowTokenIndex()
         {
             IWowTokenApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/token/index?namespace=dynamic-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/AccountProfileApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/AccountProfileApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.ProfileApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
     public class AccountProfileApiTests
     {
         [Fact]
-        public async void GetAccountProfileSummaryAsync_Gets_AccountProfileSummary()
+        public async Task GetAccountProfileSummaryAsync_Gets_AccountProfileSummary()
         {
             IAccountProfileApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/user/wow?namespace=profile-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
         }
 
         [Fact]
-        public async void GetProtectedCharacterProfileSummaryAsync_Gets_ProtectedCharacterProfileSummary()
+        public async Task GetProtectedCharacterProfileSummaryAsync_Gets_ProtectedCharacterProfileSummary()
         {
             IAccountProfileApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/user/wow/protected-character/1262-107811065?namespace=profile-us&locale=en_US",
@@ -28,7 +29,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
         }
 
         [Fact]
-        public async void GetAccountCollectionsIndexAsync_Gets_AccountCollectionsIndex()
+        public async Task GetAccountCollectionsIndexAsync_Gets_AccountCollectionsIndex()
         {
             IAccountProfileApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/user/wow/collections?namespace=profile-us&locale=en_US",
@@ -39,7 +40,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
         }
 
         [Fact]
-        public async void GetAccountMountsCollectionSummaryAsync_Gets_AccountMountsCollectionSummary()
+        public async Task GetAccountMountsCollectionSummaryAsync_Gets_AccountMountsCollectionSummary()
         {
             IAccountProfileApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/user/wow/collections/mounts?namespace=profile-us&locale=en_US",
@@ -50,7 +51,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
         }
 
         [Fact]
-        public async void GetAccountPetsCollectionSummaryAsync_Gets_AccountPetsCollectionSummary()
+        public async Task GetAccountPetsCollectionSummaryAsync_Gets_AccountPetsCollectionSummary()
         {
             IAccountProfileApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/user/wow/collections/pets?namespace=profile-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterAchievementsApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterAchievementsApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.ProfileApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
     public class CharacterAchievementsApiTests
     {
         [Fact]
-        public async void GetCharacterAchievementsSummaryAsync_Gets_CharacterAchievementsSummary()
+        public async Task GetCharacterAchievementsSummaryAsync_Gets_CharacterAchievementsSummary()
         {
             ICharacterAchievementsApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/wow/character/norgannon/drinian/achievements?namespace=profile-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
         }
 
         [Fact]
-        public async void GetCharacterAchievementStatisticsAsync_Gets_CharacterAchievementStatistics()
+        public async Task GetCharacterAchievementStatisticsAsync_Gets_CharacterAchievementStatistics()
         {
             ICharacterAchievementsApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/wow/character/norgannon/drinian/achievements/statistics?namespace=profile-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterAppearanceApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterAppearanceApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.ProfileApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
     public class CharacterAppearanceApiTests
     {
         [Fact]
-        public async void GetCharacterAppearanceSummaryAsync_Gets_CharacterAppearanceSummary()
+        public async Task GetCharacterAppearanceSummaryAsync_Gets_CharacterAppearanceSummary()
         {
             ICharacterAppearanceApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/wow/character/norgannon/drinian/appearance?namespace=profile-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterCollectionsApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterCollectionsApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.ProfileApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
     public class CharacterCollectionsApiTests
     {
         [Fact]
-        public async void GetCharacterCollectionsIndexAsync_Gets_CharacterCollections()
+        public async Task GetCharacterCollectionsIndexAsync_Gets_CharacterCollections()
         {
             ICharacterCollectionsApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/wow/character/norgannon/drinian/collections?namespace=profile-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
         }
 
         [Fact]
-        public async void GetCharacterMountsCollectionSummaryAsync_Gets_CharacterMountsSummary()
+        public async Task GetCharacterMountsCollectionSummaryAsync_Gets_CharacterMountsSummary()
         {
             ICharacterCollectionsApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/wow/character/norgannon/drinian/collections/mounts?namespace=profile-us&locale=en_US",
@@ -28,7 +29,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
         }
 
         [Fact]
-        public async void GetCharacterPetsCollectionSummaryAsync_Gets_CharacterPetsSummary()
+        public async Task GetCharacterPetsCollectionSummaryAsync_Gets_CharacterPetsSummary()
         {
             ICharacterCollectionsApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/wow/character/norgannon/drinian/collections/pets?namespace=profile-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterEncountersApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterEncountersApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.ProfileApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
     public class CharacterEncountersApiTests
     {
         [Fact]
-        public async void GetCharacterEncountersSummaryAsync_Gets_CharacterEncountersSummary()
+        public async Task GetCharacterEncountersSummaryAsync_Gets_CharacterEncountersSummary()
         {
             ICharacterEncountersApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/wow/character/norgannon/drinian/encounters?namespace=profile-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
         }
 
         [Fact]
-        public async void GetCharacterDungeonsAsync_Gets_CharacterDungeons()
+        public async Task GetCharacterDungeonsAsync_Gets_CharacterDungeons()
         {
             ICharacterEncountersApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/wow/character/norgannon/drinian/encounters/dungeons?namespace=profile-us&locale=en_US",
@@ -28,7 +29,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
         }
 
         [Fact]
-        public async void GetCharacterRaidsAsync_Gets_CharacterRaids()
+        public async Task GetCharacterRaidsAsync_Gets_CharacterRaids()
         {
             ICharacterEncountersApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/wow/character/norgannon/drinian/encounters/raids?namespace=profile-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterEquipmentApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterEquipmentApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.ProfileApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
     public class CharacterEquipmentApiTests
     {
         [Fact]
-        public async void GetCharacterEquipmentSummaryAsync_Gets_CharacterEquipmentSummary()
+        public async Task GetCharacterEquipmentSummaryAsync_Gets_CharacterEquipmentSummary()
         {
             ICharacterEquipmentApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/wow/character/norgannon/drinian/equipment?namespace=profile-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterHunterPetsApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterHunterPetsApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.ProfileApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
     public class CharacterHunterPetsApiTests
     {
         [Fact]
-        public async void GetCharacterHunterPetsSummaryAsync_Gets_CharacterHunterPetsSummary()
+        public async Task GetCharacterHunterPetsSummaryAsync_Gets_CharacterHunterPetsSummary()
         {
             ICharacterHunterPetsApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/wow/character/norgannon/anradin/hunter-pets?namespace=profile-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterMediaApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterMediaApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.ProfileApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
     public class CharacterMediaApiTests
     {
         [Fact]
-        public async void GetCharacterMediaSummaryAsync_Gets_CharacterMediaSummary()
+        public async Task GetCharacterMediaSummaryAsync_Gets_CharacterMediaSummary()
         {
             ICharacterMediaApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/wow/character/norgannon/drinian/character-media?namespace=profile-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterMythicKeystoneProfileApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterMythicKeystoneProfileApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.ProfileApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
     public class CharacterMythicKeystoneProfileApiTests
     {
         [Fact]
-        public async void GetCharacterMythicKeystoneProfileIndexAsync_Gets_CharacterMythicKeystoneProfileIndex()
+        public async Task GetCharacterMythicKeystoneProfileIndexAsync_Gets_CharacterMythicKeystoneProfileIndex()
         {
             ICharacterMythicKeystoneProfileApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/wow/character/zuljin/volladin/mythic-keystone-profile?namespace=profile-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
         }
 
         [Fact]
-        public async void GetCharacterMythicKeystoneSeasonDetailsAsync_Gets_CharacterMythicKeystoneSeasonDetails()
+        public async Task GetCharacterMythicKeystoneSeasonDetailsAsync_Gets_CharacterMythicKeystoneSeasonDetails()
         {
             ICharacterMythicKeystoneProfileApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/wow/character/zuljin/volladin/mythic-keystone-profile/season/1?namespace=profile-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterProfessionsApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterProfessionsApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.ProfileApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
     public class CharacterProfessionsApiTests
     {
         [Fact]
-        public async void GetCharacterProfessionsSummaryAsync_Gets_CharacterProfessionsSummary()
+        public async Task GetCharacterProfessionsSummaryAsync_Gets_CharacterProfessionsSummary()
         {
             ICharacterProfessionsApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/wow/character/norgannon/drinian/professions?namespace=profile-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterProfileApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterProfileApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.ProfileApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
     public class CharacterProfileApiTests
     {
         [Fact]
-        public async void GetCharacterProfileSummaryAsync_Gets_CharacterProfileSummary()
+        public async Task GetCharacterProfileSummaryAsync_Gets_CharacterProfileSummary()
         {
             ICharacterProfileApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/wow/character/norgannon/drinian?namespace=profile-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
         }
 
         [Fact]
-        public async void GetCharacterStatusAsync_Gets_CharacterStatus()
+        public async Task GetCharacterStatusAsync_Gets_CharacterStatus()
         {
             ICharacterProfileApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/wow/character/norgannon/drinian/status?namespace=profile-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterPvpApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterPvpApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.ProfileApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
     public class CharacterPvpApiTests
     {
         [Fact]
-        public async void GetCharacterPvpBracketStatisticsAsync_Gets_PvpBracketStatistics()
+        public async Task GetCharacterPvpBracketStatisticsAsync_Gets_PvpBracketStatistics()
         {
             ICharacterPvpApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/wow/character/malganis/zenli/pvp-bracket/3v3?namespace=profile-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
         }
 
         [Fact]
-        public async void GetCharacterPvpSummaryAsync_Gets_CharacterPvpSummary()
+        public async Task GetCharacterPvpSummaryAsync_Gets_CharacterPvpSummary()
         {
             ICharacterPvpApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/wow/character/malganis/zenli/pvp-summary?namespace=profile-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterQuestsApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterQuestsApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.ProfileApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
     public class CharacterQuestsApiTests
     {
         [Fact]
-        public async void GetCharacterQuestsAsync_Gets_CharacterQuests()
+        public async Task GetCharacterQuestsAsync_Gets_CharacterQuests()
         {
             ICharacterQuestsApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/wow/character/norgannon/drinian/quests?namespace=profile-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
         }
 
         [Fact]
-        public async void GetCharacterCompletedQuestsAsync_Gets_CharacterCompletedQuests()
+        public async Task GetCharacterCompletedQuestsAsync_Gets_CharacterCompletedQuests()
         {
             ICharacterQuestsApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/wow/character/norgannon/drinian/quests/completed?namespace=profile-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterReputationsApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterReputationsApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.ProfileApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
     public class CharacterReputationsApiTests
     {
         [Fact]
-        public async void GetCharacterReputationsSummaryAsync_Gets_CharacterReputationsSummary()
+        public async Task GetCharacterReputationsSummaryAsync_Gets_CharacterReputationsSummary()
         {
             ICharacterReputationsApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/wow/character/norgannon/drinian/reputations?namespace=profile-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterSpecializationsApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterSpecializationsApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.ProfileApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
     public class CharacterSpecializationsApiTests
     {
         [Fact]
-        public async void GetCharacterSpecializationsSummaryAsync_Gets_CharacterSpecializationsSummary()
+        public async Task GetCharacterSpecializationsSummaryAsync_Gets_CharacterSpecializationsSummary()
         {
             ICharacterSpecializationsApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/wow/character/norgannon/drinian/specializations?namespace=profile-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterStatisticsApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterStatisticsApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.ProfileApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
     public class CharacterStatisticsApiTests
     {
         [Fact]
-        public async void GetCharacterStatisticsSummaryAsync_Gets_CharacterStatisticsSummary()
+        public async Task GetCharacterStatisticsSummaryAsync_Gets_CharacterStatisticsSummary()
         {
             ICharacterStatisticsApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/wow/character/norgannon/drinian/statistics?namespace=profile-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterTitlesApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/CharacterTitlesApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.ProfileApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
     public class CharacterTitlesApiTests
     {
         [Fact]
-        public async void GetCharacterTitlesSummaryAsync_Gets_CharacterTitlesSummary()
+        public async Task GetCharacterTitlesSummaryAsync_Gets_CharacterTitlesSummary()
         {
             ICharacterTitlesApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/profile/wow/character/norgannon/drinian/titles?namespace=profile-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/GuildApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/ProfileApi/GuildApiTests.cs
@@ -1,4 +1,5 @@
-﻿using ArgentPonyWarcraftClient.Tests.Properties;
+﻿using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
 namespace ArgentPonyWarcraftClient.Tests.ProfileApi
@@ -6,7 +7,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
     public class GuildApiTests
     {
         [Fact]
-        public async void GetGuildAsync_Gets_Guild()
+        public async Task GetGuildAsync_Gets_Guild()
         {
             IGuildApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/guild/deathwing/enigma?namespace=profile-us&locale=en_US",
@@ -17,7 +18,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
         }
 
         [Fact]
-        public async void GetGuildActivityAsync_Gets_GuildActivity()
+        public async Task GetGuildActivityAsync_Gets_GuildActivity()
         {
             IGuildApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/guild/deathwing/enigma/activity?namespace=profile-us&locale=en_US",
@@ -28,7 +29,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
         }
 
         [Fact]
-        public async void GetGuildAchievementsAsync_Gets_GuildAchievements()
+        public async Task GetGuildAchievementsAsync_Gets_GuildAchievements()
         {
             IGuildApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/guild/deathwing/enigma/achievements?namespace=profile-us&locale=en_US",
@@ -39,7 +40,7 @@ namespace ArgentPonyWarcraftClient.Tests.ProfileApi
         }
 
         [Fact]
-        public async void GetGuildRosterAsync_Gets_GuildRoster()
+        public async Task GetGuildRosterAsync_Gets_GuildRoster()
         {
             IGuildApi warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/guild/deathwing/enigma/roster?namespace=profile-us&locale=en_US",

--- a/tests/ArgentPonyWarcraftClient.Tests/WarcraftClientTestsErrorConditions.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/WarcraftClientTestsErrorConditions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net;
+using System.Threading.Tasks;
 using ArgentPonyWarcraftClient.Tests.Properties;
 using Xunit;
 
@@ -8,7 +9,7 @@ namespace ArgentPonyWarcraftClient.Tests
     public class WarcraftClientTestsErrorConditions
     {
         [Fact]
-        public async void InvalidIdProducesNotFoundError()
+        public async Task InvalidIdProducesNotFoundError()
         {
             IWarcraftClient warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/item/99999991?namespace=static-us&locale=en_US",
@@ -23,7 +24,7 @@ namespace ArgentPonyWarcraftClient.Tests
         }
 
         [Fact]
-        public async void InvalidJsonProducesError()
+        public async Task InvalidJsonProducesError()
         {
             IWarcraftClient warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/journal-encounter/89?namespace=static-us&locale=en_US",
@@ -38,7 +39,7 @@ namespace ArgentPonyWarcraftClient.Tests
         }
 
         [Fact]
-        public async void ProducesForbiddenError()
+        public async Task ProducesForbiddenError()
         {
             IWarcraftClient warcraftClient = ClientFactory.BuildMockClient(
                 requestUri: "https://us.api.blizzard.com/data/wow/item/19019?namespace=static-us&locale=en_US",


### PR DESCRIPTION
Converted tests to return async Task instead of async void to comply with best practices described at https://docs.microsoft.com/en-us/archive/msdn-magazine/2013/march/async-await-best-practices-in-asynchronous-programming#avoid-async-void.