### PR TITLE
Updated ChararacterMediaSummary to include an Assets property

### DIFF
--- a/src/ArgentPonyWarcraftClient/Models/ProfileApi/CharacterMedia/CharacterMediaSummary.cs
+++ b/src/ArgentPonyWarcraftClient/Models/ProfileApi/CharacterMedia/CharacterMediaSummary.cs
@@ -21,21 +21,9 @@ namespace ArgentPonyWarcraftClient
         public CharacterReference Character { get; set; }
 
         /// <summary>
-        /// Gets a URL for a render of the character's avatar.
+        /// Gets media assets associated with the character.
         /// </summary>
-        [JsonPropertyName("avatar_url")]
-        public Uri AvatarUrl { get; set; }
-
-        /// <summary>
-        /// Gets a URL for a render of the character bust.
-        /// </summary>
-        [JsonPropertyName("bust_url")]
-        public Uri BustUrl { get; set; }
-
-        /// <summary>
-        /// Gets a URL for the main render of the character.
-        /// </summary>
-        [JsonPropertyName("render_url")]
-        public Uri RenderUrl { get; set; }
+        [JsonPropertyName("assets")]
+        public Asset[] Assets { get; set; }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
@@ -73323,9 +73323,24 @@
       "slug": "norgannon"
     }
   },
-  "avatar_url": "https://render-us.worldofwarcraft.com/character/norgannon/59/183057723-avatar.jpg",
-  "bust_url": "https://render-us.worldofwarcraft.com/character/norgannon/59/183057723-inset.jpg",
-  "render_url": "https://render-us.worldofwarcraft.com/character/norgannon/59/183057723-main.jpg"
+  "assets": [
+    {
+      "key": "avatar",
+      "value": "https://render-us.worldofwarcraft.com/character/norgannon/59/183057723-avatar.jpg"
+    },
+    {
+      "key": "inset",
+      "value": "https://render-us.worldofwarcraft.com/character/norgannon/59/183057723-inset.jpg"
+    },
+    {
+      "key": "main",
+      "value": "https://render-us.worldofwarcraft.com/character/norgannon/59/183057723-main.jpg"
+    },
+    {
+      "key": "main-raw",
+      "value": "https://render-us.worldofwarcraft.com/character/norgannon/59/183057723-main-raw.png"
+    }
+  ]
 }</value>
   </data>
   <data name="ModifiedCraftingCategoryIndexResponse" xml:space="preserve">


### PR DESCRIPTION
Updated ChararacterMediaSummary to include an Assets property instead of separate AvatarUrl, BustUrl, and RenderUrl properties.  Resolves #167.