### PR TITLE
Updated tests to multi-target different frameworks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   my-executor:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:3.1
+      - image: mcr.microsoft.com/dotnet/sdk:5.0
     working_directory: /app
 
 jobs:

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "trx2junit": {
-      "version": "1.3.1",
+      "version": "1.4.0",
       "commands": [
         "trx2junit"
       ]

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "5.0.100",
+    "rollForward": "latestMajor"
+  }
+}

--- a/tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests.csproj
+++ b/tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests.csproj
+++ b/tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+        <TargetFramework>net5.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/ArgentPonyWarcraftClient.Integration.Tests.csproj
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/ArgentPonyWarcraftClient.Integration.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/ArgentPonyWarcraftClient.Integration.Tests.csproj
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/ArgentPonyWarcraftClient.Integration.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/TestUtilities/ResilientMessageBus.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/TestUtilities/ResilientMessageBus.cs
@@ -28,10 +28,6 @@ namespace ArgentPonyWarcraftClient.Integration.Tests
                 string exceptionType = testFailed.ExceptionTypes.FirstOrDefault();
                 CanRetry = exceptionType == typeof(HttpRequestException).FullName;
             }
-            else
-            {
-                CanRetry = false;
-            }
 
             lock (_messages)
             {

--- a/tests/ArgentPonyWarcraftClient.Tests/ArgentPonyWarcraftClient.Tests.csproj
+++ b/tests/ArgentPonyWarcraftClient.Tests/ArgentPonyWarcraftClient.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/ArgentPonyWarcraftClient.Tests/ArgentPonyWarcraftClient.Tests.csproj
+++ b/tests/ArgentPonyWarcraftClient.Tests/ArgentPonyWarcraftClient.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated all test projects to multitarget netcoreapp2.1 (LTS), netcoreapp3.1 (LTS), and net5.0 (current).  Updated CircleCI to use mcr.microsoft.com/dotnet/sdk:5.0 as the Docker image for building.  Also fixed ResilientMessageBus so it never resets the CanRetry property after it has encountered a potentially recoverable error.  Resolves #169.