### PR TITLE
Updated Enchantment properties

### DIFF
--- a/src/ArgentPonyWarcraftClient/Models/ProfileApi/CharacterEquipment/Enchantment.cs
+++ b/src/ArgentPonyWarcraftClient/Models/ProfileApi/CharacterEquipment/Enchantment.cs
@@ -14,16 +14,15 @@ namespace ArgentPonyWarcraftClient
         public string DisplayString { get; set; }
 
         /// <summary>
-        /// Gets the enchantment_id for the enchantment.
+        /// Gets the enchantment ID for the enchantment.
         /// </summary>
         [JsonPropertyName("enchantment_id")]
-        public int enchantment_id { get; set; }
+        public int EnchantmentId { get; set; }
 
         /// <summary>
         /// Gets a reference to the item.
         /// </summary>
         [JsonPropertyName("source_item")]
-        public ItemReference Item { get; set; }
-
+        public ItemReference SourceItem { get; set; }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/MythicKeystoneDungeonApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/MythicKeystoneDungeonApiTests.cs
@@ -17,7 +17,7 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetMythicKeystoneDungeonAsync_Gets_MythicKeystoneDungeon()
         {
             IMythicKeystoneDungeonApi warcraftClient = ClientFactory.BuildClient();
-            RequestResult<MythicKeystoneDungeon> result = await warcraftClient.GetMythicKeystoneDungeonAsync(353, "dynamic-us");
+            RequestResult<MythicKeystoneDungeon> result = await warcraftClient.GetMythicKeystoneDungeonAsync(375, "dynamic-us");
             Assert.NotNull(result.Value);
         }
 


### PR DESCRIPTION
Updated Enchantment properties to match naming conventions, changing enchantment_id to EnchantmentId and Item to SourceItem.

Also updated the ID used in the GetMythicKeystoneDungeonAsync_Gets_MythicKeystoneDungeon test.  The previous ID was no longer valid after the release of new mythic dungeons for the Shadowlands expansion.