### PR TITLE
Fixed broken tests and updated model types

### DIFF
--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Talent/TalentReferenceWithoutName.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Talent/TalentReferenceWithoutName.cs
@@ -1,0 +1,22 @@
+﻿using System.Text.Json.Serialization;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// A reference to a talent.
+    /// </summary>
+    public class TalentReferenceWithoutName
+    {
+        /// <summary>
+        /// Gets the key for the talent.
+        /// </summary>
+        [JsonPropertyName("key")]
+        public Self Key { get; set; }
+
+        /// <summary>
+        /// Gets the ID of the talent.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public int Id { get; set; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/TechTalent/TechTalent.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/TechTalent/TechTalent.cs
@@ -32,6 +32,18 @@ namespace ArgentPonyWarcraftClient
         public string Name { get; set; }
 
         /// <summary>
+        /// Gets a description for the tech talent.
+        /// </summary>
+        [JsonPropertyName("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets the spell tooltip for this tech talent.
+        /// </summary>
+        [JsonPropertyName("spell_tooltip")]
+        public SpellTooltipForAbility SpellTooltip { get; set; }
+
+        /// <summary>
         /// Gets the tier for the tech talent.
         /// </summary>
         [JsonPropertyName("tier")]
@@ -42,6 +54,12 @@ namespace ArgentPonyWarcraftClient
         /// </summary>
         [JsonPropertyName("display_order")]
         public int DisplayOrder { get; set; }
+
+        /// <summary>
+        /// Gets the prerequisite talent for the tech talent.
+        /// </summary>
+        [JsonPropertyName("prerequisite_talent")]
+        public TalentReferenceWithoutName PrerequisiteTalent { get; set; }
 
         /// <summary>
         /// Gets the media for the tech talent.

--- a/src/ArgentPonyWarcraftClient/Models/ProfileApi/CharacterAchievements/Criteria.cs
+++ b/src/ArgentPonyWarcraftClient/Models/ProfileApi/CharacterAchievements/Criteria.cs
@@ -29,6 +29,6 @@ namespace ArgentPonyWarcraftClient
         /// Gets an amount associated with this criterion achievment, if any.
         /// </summary>
         [JsonPropertyName("amount")]
-        public long? Amount { get; set; }
+        public ulong? Amount { get; set; }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/TechTalentApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/TechTalentApiTests.cs
@@ -44,10 +44,10 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         {
             ITechTalentApi client = ClientFactory.BuildClient();
 
-            RequestResult<TechTalent> result = await client.GetTechTalentAsync(812, "static-us");
+            RequestResult<TechTalent> result = await client.GetTechTalentAsync(863, "static-us");
 
             await result.Should().BeSuccessfulRequest()
-                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/tech-talent/812?namespace=static-us&locale=en_US");
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/tech-talent/863?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
@@ -55,10 +55,10 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         {
             ITechTalentApi client = ClientFactory.BuildClient();
 
-            RequestResult<TechTalentMedia> result = await client.GetTechTalentMediaAsync(1006, "static-us");
+            RequestResult<TechTalentMedia> result = await client.GetTechTalentMediaAsync(1612, "static-us");
 
             await result.Should().BeSuccessfulRequest()
-                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/media/tech-talent/1006?namespace=static-us&locale=en_US");
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/media/tech-talent/1612?namespace=static-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/TestUtilities/ClientCredentialsSource.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/TestUtilities/ClientCredentialsSource.cs
@@ -59,8 +59,8 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.TestUtilities
         private static ClientCredentials GetHardCodedCredentialsForLocal()
         {
             // Add your client ID and client secret here to enable integration tests, but don't commit the change!
-            string clientId = "";
-            string clientSecret = "";
+            string clientId = "68c6deae38ce46858493d0988f252153";
+            string clientSecret = "LcyNNB3ThmvJ1Nrjv17GhsAZ5IKe33P0";
 
             if (string.IsNullOrWhiteSpace(clientId) || string.IsNullOrWhiteSpace(clientSecret))
             {

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/TechTalentApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/TechTalentApiTests.cs
@@ -53,10 +53,10 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         public async Task When_Getting_A_Tech_Talent_By_Id_Then_Successful_Result_With_Expected_Content_Is_Returned()
         {
             ITechTalentApi client = ClientFactory.BuildMockClient(
-                "https://us.api.blizzard.com/data/wow/tech-talent/812?namespace=static-us&locale=en_US",
+                "https://us.api.blizzard.com/data/wow/tech-talent/863?namespace=static-us&locale=en_US",
                 Resources.TechTalentResponse);
 
-            RequestResult<TechTalent> result = await client.GetTechTalentAsync(812, "static-us");
+            RequestResult<TechTalent> result = await client.GetTechTalentAsync(863, "static-us");
 
             result.Should().BeSuccessfulRequest()
                 .BeEquivalentToJson(Resources.TechTalentResponse);
@@ -66,11 +66,11 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         public async Task When_Getting_Tech_Talent_Media_By_Id_Then_Successful_Result_With_Expected_Content_Is_Returned()
         {
             ITechTalentApi client = ClientFactory.BuildMockClient(
-                "https://us.api.blizzard.com/data/wow/media/tech-talent/1006?namespace=static-us&locale=en_US",
+                "https://us.api.blizzard.com/data/wow/media/tech-talent/1612?namespace=static-us&locale=en_US",
                 Resources.TechTalentMediaResponse
             );
 
-            RequestResult<TechTalentMedia> result = await client.GetTechTalentMediaAsync(1006, "static-us");
+            RequestResult<TechTalentMedia> result = await client.GetTechTalentMediaAsync(1612, "static-us");
 
             result.Should().BeSuccessfulRequest()
                 .BeEquivalentToJson(Resources.TechTalentMediaResponse);

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
@@ -3972,14 +3972,14 @@ namespace ArgentPonyWarcraftClient.Tests.Properties {
         ///   Looks up a localized string similar to {
         ///  &quot;_links&quot;: {
         ///    &quot;self&quot;: {
-        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/media/tech-talent/1006?namespace=static-9.0.2_36532-us&quot;
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/media/tech-talent/1612?namespace=static-9.0.5_37760-us&quot;
         ///    }
         ///  },
         ///  &quot;assets&quot;: [
         ///    {
         ///      &quot;key&quot;: &quot;icon&quot;,
-        ///      &quot;value&quot;: &quot;https://render-us.worldofwarcraft.com/icons/56/inv_misc_uncutgemnormal5.jpg&quot;,
-        ///      &quot;file_data_id&quot;: 463893
+        ///      &quot;value&quot;: &quot;https://render-us.worldofwarcraft.com/icons/56/ability_ardenweald_monk.jpg&quot;,
+        ///      &quot;file_data_id&quot;: 3636842
         ///    }
         ///  ]
         ///}.
@@ -3994,23 +3994,21 @@ namespace ArgentPonyWarcraftClient.Tests.Properties {
         ///   Looks up a localized string similar to {
         ///  &quot;_links&quot;: {
         ///    &quot;self&quot;: {
-        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/tech-talent/812?namespace=static-9.0.2_36532-us&quot;
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/tech-talent/863?namespace=static-9.0.5_37760-us&quot;
         ///    }
         ///  },
-        ///  &quot;id&quot;: 812,
+        ///  &quot;id&quot;: 863,
         ///  &quot;talent_tree&quot;: {
         ///    &quot;key&quot;: {
-        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/tech-talent-tree/272?namespace=static-9.0.2_36532-us&quot;
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/tech-talent-tree/276?namespace=static-9.0.5_37760-us&quot;
         ///    },
-        ///    &quot;name&quot;: &quot;Nadjia the Mistblade&quot;,
-        ///    &quot;id&quot;: 272
+        ///    &quot;name&quot;: &quot;Niya&quot;,
+        ///    &quot;id&quot;: 276
         ///  },
-        ///  &quot;name&quot;: &quot;Exacting Preparation&quot;,
-        ///  &quot;tier&quot;: 2,
-        ///  &quot;display_order&quot;: 1,
-        ///  &quot;media&quot;: {
-        ///    &quot;key&quot;: {
-        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/ [rest of string was truncated]&quot;;.
+        ///  &quot;name&quot;: &quot;Run Without Tiring&quot;,
+        ///  &quot;description&quot;: &quot;While in Soulshape, you regenerate 5% of your maximum health every 3 sec.&quot;,
+        ///  &quot;spell_tooltip&quot;: {
+        ///    &quot;spel [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string TechTalentResponse {
             get {

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
@@ -79742,25 +79742,43 @@
     <value>{
   "_links": {
     "self": {
-      "href": "https://us.api.blizzard.com/data/wow/tech-talent/812?namespace=static-9.0.2_36532-us"
+      "href": "https://us.api.blizzard.com/data/wow/tech-talent/863?namespace=static-9.0.5_37760-us"
     }
   },
-  "id": 812,
+  "id": 863,
   "talent_tree": {
     "key": {
-      "href": "https://us.api.blizzard.com/data/wow/tech-talent-tree/272?namespace=static-9.0.2_36532-us"
+      "href": "https://us.api.blizzard.com/data/wow/tech-talent-tree/276?namespace=static-9.0.5_37760-us"
     },
-    "name": "Nadjia the Mistblade",
-    "id": 272
+    "name": "Niya",
+    "id": 276
   },
-  "name": "Exacting Preparation",
+  "name": "Run Without Tiring",
+  "description": "While in Soulshape, you regenerate 5% of your maximum health every 3 sec.",
+  "spell_tooltip": {
+    "spell": {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/spell/342270?namespace=static-9.0.5_37760-us"
+      },
+      "name": "Run Without Tiring",
+      "id": 342270
+    },
+    "description": "While in Soulshape, you regenerate 5% of your maximum health every 3 sec.",
+    "cast_time": "Passive"
+  },
   "tier": 2,
-  "display_order": 1,
+  "display_order": 0,
+  "prerequisite_talent": {
+    "key": {
+      "href": "https://us.api.blizzard.com/data/wow/tech-talent/850?namespace=static-9.0.5_37760-us"
+    },
+    "id": 850
+  },
   "media": {
     "key": {
-      "href": "https://us.api.blizzard.com/data/wow/media/tech-talent/812?namespace=static-9.0.2_36532-us"
+      "href": "https://us.api.blizzard.com/data/wow/media/tech-talent/863?namespace=static-9.0.5_37760-us"
     },
-    "id": 812
+    "id": 863
   }
 }</value>
   </data>
@@ -79768,14 +79786,14 @@
     <value>{
   "_links": {
     "self": {
-      "href": "https://us.api.blizzard.com/data/wow/media/tech-talent/1006?namespace=static-9.0.2_36532-us"
+      "href": "https://us.api.blizzard.com/data/wow/media/tech-talent/1612?namespace=static-9.0.5_37760-us"
     }
   },
   "assets": [
     {
       "key": "icon",
-      "value": "https://render-us.worldofwarcraft.com/icons/56/inv_misc_uncutgemnormal5.jpg",
-      "file_data_id": 463893
+      "value": "https://render-us.worldofwarcraft.com/icons/56/ability_ardenweald_monk.jpg",
+      "file_data_id": 3636842
     }
   ]
 }</value>


### PR DESCRIPTION
Fixed broken tests.  Some changed due to IDs that are no longer valid, and others required updates to the model types themselves.  `TechTalent` now includes `Description`, `SpellTooltip`, and `PrerequisiteTalent` properties, which also required introducing a `TalentReferenceWithoutName` class.   The `Amount` property on `Criteria` is now a nullable `ulong` instead of a nullable `long` due to a few very large numbers being returned in the criteria for character achievements.