### PR TITLE
Updated NuGet packages

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-format": {
-      "version": "4.1.131201",
+      "version": "5.0.211103",
       "commands": [
         "dotnet-format"
       ]

--- a/src/ArgentPonyWarcraftClient.Extensions.DependencyInjection/ArgentPonyWarcraftClient.Extensions.DependencyInjection.csproj
+++ b/src/ArgentPonyWarcraftClient.Extensions.DependencyInjection/ArgentPonyWarcraftClient.Extensions.DependencyInjection.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/ArgentPonyWarcraftClient.Extensions.DependencyInjection/ArgentPonyWarcraftClient.Extensions.DependencyInjection.csproj
+++ b/src/ArgentPonyWarcraftClient.Extensions.DependencyInjection/ArgentPonyWarcraftClient.Extensions.DependencyInjection.csproj
@@ -12,7 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/ArgentPonyWarcraftClient/ArgentPonyWarcraftClient.csproj
+++ b/src/ArgentPonyWarcraftClient/ArgentPonyWarcraftClient.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
+    <PackageReference Include="System.Text.Json" Version="5.0.1" />
   </ItemGroup>
 
 </Project>

--- a/tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests.csproj
+++ b/tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
           <PrivateAssets>all</PrivateAssets>

--- a/tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests.csproj
+++ b/tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests.csproj
@@ -12,7 +12,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="1.3.0">
+        <PackageReference Include="coverlet.collector" Version="3.0.3">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/ArgentPonyWarcraftClient.Integration.Tests.csproj
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/ArgentPonyWarcraftClient.Integration.Tests.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="FluentAssertions.Json" Version="5.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/ArgentPonyWarcraftClient.Tests/ArgentPonyWarcraftClient.Tests.csproj
+++ b/tests/ArgentPonyWarcraftClient.Tests/ArgentPonyWarcraftClient.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
Updated several NuGet packages:

- Updated **Microsoft.NET.Test.Sdk** from 16.7.1 to 16.9.1
- Updated **coverlet.collector** from 1.3.0 to 3.0.3
- Removed an unnecessary dependency on the **Microsoft.Extensions.DependencyInjection** NuGet package.  The **Microsoft.Extensions.Http** dependency pulls in **Microsoft.Extensions.DependencyInjection.Abstractions**, which is sufficient
- Updated **Microsoft.Extensions.Http** from 3.0.0 to 5.0.0
- Updated **System.Text.Json** from 4.7.2 to 5.0.1
- Updated the **dotnet-format** tool from 4.1.131201 to 5.0.211103