### PR TITLE
Fixed the dotnet nuget push step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,12 +34,12 @@ jobs:
       with:
         name: NuGet packages
         path: |
-          ${{ github.workspace }}/artifacts/*.nupkg
-          ${{ github.workspace }}/artifacts/*.snupkg
+          artifacts/*.nupkg
+          artifacts/*.snupkg
 
     - name: Push NuGet packages to NuGet
       if: ${{ startsWith(github.ref, 'refs/tags/v') }} # Only for a tag
-      run: dotnet nuget push "artifacts/*.nupkg" --skip-duplicate --api-key ${{ secrets.NUGET_KEY }} --source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push "artifacts/**.nupkg" --skip-duplicate --api-key ${{ secrets.NUGET_KEY }} --source https://api.nuget.org/v3/index.json
 
     - name: Create GitHub Release
       if: ${{ startsWith(github.ref, 'refs/tags/v') }} # Only for a tag


### PR DESCRIPTION
Fixed the `dotnet nuget push` step.  It requires two asterisks in the wildcard for the *.nupkg name instead of one.  Also removed an unnecessary `github.workspace` prefix.