### PR TITLE
Updated GitHub Actions to build on ubuntu-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Artifacts" Version="2.1.6" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Artifacts" Version="2.2.0" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updated GitHub Actions to build on **ubuntu-latest** instead of **windows-latest** after updating [Microsoft.Build.Artifacts](https://github.com/microsoft/MSBuildSdks/tree/main/src/Artifacts) from 2.1.6 to 2.2.0 to address https://github.com/microsoft/MSBuildSdks/issues/233.  Resolves #189.