### PR TITLE
added queue manager

### DIFF
--- a/src/ArgentPonyWarcraftClient.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/ArgentPonyWarcraftClient.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -57,7 +57,7 @@ namespace ArgentPonyWarcraftClient.Extensions.DependencyInjection
                 "ArgentPonyWarcraftClient.WarcraftClient.HttpClient",
                 client => client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"))
             ).AddTypedClient(httpClient =>
-                new WarcraftClient(clientId, clientSecret, region, locale, httpClient)
+                new WarcraftClient(clientId, clientSecret, region, locale, httpClient, QueueManagerFactory.Instance)
             );
 
             services.AddTransientUsingServiceProvider<IWarcraftClient, WarcraftClient>()

--- a/src/ArgentPonyWarcraftClient/Interfaces/IQueueManager.cs
+++ b/src/ArgentPonyWarcraftClient/Interfaces/IQueueManager.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    ///     Queue manager which grand access not often then 100 times per second 
+    /// </summary>
+    public interface IQueueManager : IDisposable
+    {
+        /// <summary>
+        ///     Wait untill acces granted.
+        /// </summary>
+        void WaitForAccessToSend();
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Utilities/QueueManager.cs
+++ b/src/ArgentPonyWarcraftClient/Utilities/QueueManager.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    ///     Queue manager which grand access not often then 100 times per second 
+    /// </summary>
+    public class QueueManager : IQueueManager
+    {
+        private Queue<AutoResetEvent> _queue;
+        private CancellationTokenSource _cancelator;
+        private Queue<DateTime> _sentTimes;
+        private object _syncObject = new object();
+        private static int _maxRequestPerSecond = 100;
+        private static int _second = 1000;
+
+        /// <summary>
+        ///     Queue manager which grand access not often then 100 times per second 
+        /// </summary>
+        public QueueManager()
+        {
+            _queue = new Queue<AutoResetEvent>();
+            _cancelator = new CancellationTokenSource();
+            _sentTimes = new Queue<DateTime>();
+            Task.Run(CheckAndGrand, _cancelator.Token);
+        }
+
+        /// <summary>
+        ///     Wait untill acces granted.
+        /// </summary>
+        public void WaitForAccessToSend()
+        {
+            AutoResetEvent autoEvent = new AutoResetEvent(false);
+            lock(_syncObject)
+            {
+                _queue.Enqueue(autoEvent);
+            }
+            autoEvent.WaitOne();
+            autoEvent.Dispose();
+        }
+
+        /// <summary>
+        ///     Stop grant access
+        /// </summary>
+        public void Dispose()
+        {
+
+            _cancelator.Cancel();
+        }
+
+
+        private void CheckAndGrand()
+        {
+            while (true)
+            {
+                lock(_syncObject)
+                {
+                    if(_queue.Count > 0)
+                    {
+                        if(_sentTimes.Count == _maxRequestPerSecond)
+                        {
+                            double delta = (DateTime.Now - _sentTimes.Dequeue()).TotalMilliseconds;
+                            if(delta <= 1 * _second)
+                            {
+                                Thread.Sleep((int)(1000 - delta));
+                            }
+                        }
+                        _queue.Dequeue().Set();
+                        _sentTimes.Enqueue(DateTime.Now);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Utilities/QueueManagerFactory.cs
+++ b/src/ArgentPonyWarcraftClient/Utilities/QueueManagerFactory.cs
@@ -1,0 +1,33 @@
+﻿using System.Net.Http;
+using System.Net.Http.Headers;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    ///     QueueManagerFactory
+    /// </summary>
+    public static class QueueManagerFactory
+    {
+        private static IQueueManager _instance;
+
+        /// <summary>
+        ///     Gets the current IQueueManager instance.
+        /// </summary>
+        public static IQueueManager Instance
+        {
+            get
+            {
+                if (_instance != null)
+                {
+                    return _instance;
+                }
+                else
+                {
+                    _instance = new QueueManager();
+
+                    return _instance;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Wow api can manage only 100 request per second. After this rate most requests would fail.
It is my propose how we can manage it. I created queue manage which should be singleton and have to be added to all WarcraftClient instances.

This is not finished pull request. I want to know you opinion about functionality like this before finish it. Maybe you will propose better solution as more advanced programmer/architect.