### PR TITLE
Improved Game Data API integration tests

### DIFF
--- a/src/ArgentPonyWarcraftClient/Models/AssetWithoutFileDataId.cs
+++ b/src/ArgentPonyWarcraftClient/Models/AssetWithoutFileDataId.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Text.Json.Serialization;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// A media asset.
+    /// </summary>
+    public record AssetWithoutFileDataId
+    {
+        /// <summary>
+        /// Gets the key of the asset.
+        /// </summary>
+        [JsonPropertyName("key")]
+        public string Key { get; init; }
+
+        /// <summary>
+        /// Gets a URI for retrieving the asset value.
+        /// </summary>
+        [JsonPropertyName("value")]
+        public Uri Value { get; init; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Creature/CreatureDisplayMedia.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Creature/CreatureDisplayMedia.cs
@@ -17,7 +17,7 @@ namespace ArgentPonyWarcraftClient
         /// Gets a collection of media assets.
         /// </summary>
         [JsonPropertyName("assets")]
-        public Asset[] Assets { get; init; }
+        public AssetWithoutFileDataId[] Assets { get; init; }
 
         /// <summary>
         /// Gets the ID of the creature display.

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/GuildCrest/GuildCrestBorderMedia.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/GuildCrest/GuildCrestBorderMedia.cs
@@ -17,7 +17,7 @@ namespace ArgentPonyWarcraftClient
         /// Gets a collection of media assets.
         /// </summary>
         [JsonPropertyName("assets")]
-        public Asset[] Assets { get; init; }
+        public AssetWithoutFileDataId[] Assets { get; init; }
 
         /// <summary>
         /// Gets the ID of the guild crest border.

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/GuildCrest/GuildCrestColors.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/GuildCrest/GuildCrestColors.cs
@@ -1,0 +1,28 @@
+﻿using System.Text.Json.Serialization;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// A list of available guild crest colors.
+    /// </summary>
+    public record GuildCrestColors
+    {
+        /// <summary>
+        /// Gets the guild crest emblems.
+        /// </summary>
+        [JsonPropertyName("emblems")]
+        public Color[] Emblems { get; init; }
+
+        /// <summary>
+        /// Gets the guild crest borders.
+        /// </summary>
+        [JsonPropertyName("borders")]
+        public Color[] Borders { get; init; }
+
+        /// <summary>
+        /// Gets the guild crest borders.
+        /// </summary>
+        [JsonPropertyName("backgrounds")]
+        public Color[] Backgrounds { get; init; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/GuildCrest/GuildCrestComponentsIndex.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/GuildCrest/GuildCrestComponentsIndex.cs
@@ -24,5 +24,11 @@ namespace ArgentPonyWarcraftClient
         /// </summary>
         [JsonPropertyName("borders")]
         public GuildCrestBorder[] Borders { get; init; }
+
+        /// <summary>
+        /// Gets the guild crest colors.
+        /// </summary>
+        [JsonPropertyName("colors")]
+        public GuildCrestColors Colors { get; init; }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/GuildCrest/GuildCrestEmblemMedia.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/GuildCrest/GuildCrestEmblemMedia.cs
@@ -17,7 +17,7 @@ namespace ArgentPonyWarcraftClient
         /// Gets a collection of media assets.
         /// </summary>
         [JsonPropertyName("assets")]
-        public Asset[] Assets { get; init; }
+        public AssetWithoutFileDataId[] Assets { get; init; }
 
         /// <summary>
         /// Gets the ID of the guild crest emblem.

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Item/Item.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Item/Item.cs
@@ -102,5 +102,11 @@ namespace ArgentPonyWarcraftClient
         /// </summary>
         [JsonPropertyName("preview_item")]
         public PreviewItem PreviewItem { get; init; }
+
+        /// <summary>
+        /// Gets the purchase quantity for the item.
+        /// </summary>
+        [JsonPropertyName("purchase_quantity")]
+        public int PurchaseQuantity { get; init; }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Journal/JournalMedia.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Journal/JournalMedia.cs
@@ -17,6 +17,6 @@ namespace ArgentPonyWarcraftClient
         /// Gets a collection of media assets.
         /// </summary>
         [JsonPropertyName("assets")]
-        public Asset[] Assets { get; init; }
+        public AssetWithoutFileDataId[] Assets { get; init; }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Mount/Mount.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Mount/Mount.cs
@@ -48,5 +48,11 @@ namespace ArgentPonyWarcraftClient
         /// </summary>
         [JsonPropertyName("faction")]
         public EnumType Faction { get; init; }
+
+        /// <summary>
+        /// Gets the requiements for using the mount.
+        /// </summary>
+        [JsonPropertyName("requirements")]
+        public MountRequirements Requirements { get; init; }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Mount/MountRequirements.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Mount/MountRequirements.cs
@@ -1,0 +1,16 @@
+﻿using System.Text.Json.Serialization;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// Requirements for using a mount.
+    /// </summary>
+    public record MountRequirements
+    {
+        /// <summary>
+        /// Gets the required faction for the mount.
+        /// </summary>
+        [JsonPropertyName("faction")]
+        public EnumType Faction { get; init; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/MythicRaidLeaderboard/MythicRaidLeaderboard.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/MythicRaidLeaderboard/MythicRaidLeaderboard.cs
@@ -26,15 +26,15 @@ namespace ArgentPonyWarcraftClient
         public string CriteriaType { get; init; }
 
         /// <summary>
-        /// Gets a reference to the zone for the raid.
-        /// </summary>
-        [JsonPropertyName("zone")]
-        public ZoneReference Zone { get; init; }
-
-        /// <summary>
         /// Gets the entries for the Mythic Raid leaderboard.
         /// </summary>
         [JsonPropertyName("entries")]
         public MythicRaidLeaderboardEntry[] Entries { get; init; }
+
+        /// <summary>
+        /// Gets a reference to journal instance for the raid.
+        /// </summary>
+        [JsonPropertyName("journal_instance")]
+        public InstanceReference JournalInstance { get; init; }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Pet/Pet.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Pet/Pet.cs
@@ -97,5 +97,11 @@ namespace ArgentPonyWarcraftClient
         /// </summary>
         [JsonPropertyName("is_random_creature_display")]
         public bool IsRandomCreatureDisplay { get; init; }
+
+        /// <summary>
+        /// Gets a reference to the pet media.
+        /// </summary>
+        [JsonPropertyName("media")]
+        public PetMediaReference Media { get; init; }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Pet/PetMediaReference.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Pet/PetMediaReference.cs
@@ -1,0 +1,22 @@
+﻿using System.Text.Json.Serialization;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// A reference to pet media.
+    /// </summary>
+    public record PetMediaReference
+    {
+        /// <summary>
+        /// Gets the key for the pet media.
+        /// </summary>
+        [JsonPropertyName("key")]
+        public Self Key { get; init; }
+
+        /// <summary>
+        /// Gets the ID of the pet.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public int Id { get; init; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Quest/Quest.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Quest/Quest.cs
@@ -38,18 +38,6 @@ namespace ArgentPonyWarcraftClient
         public string Description { get; init; }
 
         /// <summary>
-        /// Gets the recommended minimum level for the quest.
-        /// </summary>
-        [JsonPropertyName("recommended_minimum_level")]
-        public int RecommendedMinimumLevel { get; init; }
-
-        /// <summary>
-        /// Gets the recommended maximum level for the quest.
-        /// </summary>
-        [JsonPropertyName("recommended_maximum_level")]
-        public int RecommendedMaximumLevel { get; init; }
-
-        /// <summary>
         /// Gets the requirements for the quest.
         /// </summary>
         [JsonPropertyName("requirements")]

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Quest/QuestRequirements.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Quest/QuestRequirements.cs
@@ -14,6 +14,12 @@ namespace ArgentPonyWarcraftClient
         public int MinCharacterLevel { get; init; }
 
         /// <summary>
+        /// Gets the maximum character level for the quest.
+        /// </summary>
+        [JsonPropertyName("max_character_level")]
+        public int MaxCharacterLevel { get; init; }
+
+        /// <summary>
         /// Gets the faction for the question (Alliance or Horde).
         /// </summary>
         [JsonPropertyName("faction")]

--- a/src/ArgentPonyWarcraftClient/Properties/AssemblyInfo.cs
+++ b/src/ArgentPonyWarcraftClient/Properties/AssemblyInfo.cs
@@ -2,3 +2,4 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests")]
 [assembly: InternalsVisibleTo("ArgentPonyWarcraftClient.Integration.Tests")]
+[assembly: InternalsVisibleTo("ArgentPonyWarcraftClient.Tests.Assertions")]

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/AchievementApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/AchievementApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,40 +10,55 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetAchievementCategoriesIndexAsync_Gets_AchievementCategoriesIndex()
         {
             IAchievementApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<AchievementCategoriesIndex> result = await warcraftClient.GetAchievementCategoriesIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/achievement-category/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetAchievementCategoryAsync_Gets_AchievementCategory()
         {
             IAchievementApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<AchievementCategory> result = await warcraftClient.GetAchievementCategoryAsync(81, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/achievement-category/81?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetAchievementsIndexAsync_Gets_AchievementsIndex()
         {
             IAchievementApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<AchievementsIndex> result = await warcraftClient.GetAchievementsIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/achievement/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetAchievementAsync_Gets_Achievement()
         {
             IAchievementApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<Achievement> result = await warcraftClient.GetAchievementAsync(6, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/achievement/6?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetAchievementMediaAsync_Gets_AchievementMedia()
         {
             IAchievementApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<AchievementMedia> result = await warcraftClient.GetAchievementMediaAsync(6, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/media/achievement/6?namespace=static-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/AuctionHouseApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/AuctionHouseApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,8 +10,11 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetAuctionsAsync_Gets_Auctions()
         {
             IAuctionHouseApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<AuctionsIndex> result = await warcraftClient.GetAuctionsAsync(4, "dynamic-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/connected-realm/4/auctions?namespace=dynamic-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/AzeriteEssenceApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/AzeriteEssenceApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,24 +10,33 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetAzeriteEssencesIndexAsync_Gets_AzeriteEssencesIndex()
         {
             IAzeriteEssenceApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<AzeriteEssencesIndex> result = await warcraftClient.GetAzeriteEssencesIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/azerite-essence/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetAzeriteEssenceAsync_Gets_AzeriteEssence()
         {
             IAzeriteEssenceApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<AzeriteEssence> result = await warcraftClient.GetAzeriteEssenceAsync(2, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/azerite-essence/2?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetAzeriteEssenceMediaAsync_Gets_AzeriteEssenceMedia()
         {
             IAzeriteEssenceApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<AzeriteEssenceMedia> result = await warcraftClient.GetAzeriteEssenceMediaAsync(2, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/media/azerite-essence/2?namespace=static-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/ConnectedRealmApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/ConnectedRealmApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,16 +10,22 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetPlayableRacesIndexAsync_Gets_PlayableRacesIndex()
         {
             IConnectedRealmApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<ConnectedRealmsIndex> result = await warcraftClient.GetConnectedRealmsIndexAsync("dynamic-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/connected-realm/index?namespace=dynamic-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetRealmAsync_Gets_Realm()
         {
             IConnectedRealmApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<ConnectedRealm> result = await warcraftClient.GetConnectedRealmAsync(11, "dynamic-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/connected-realm/11?namespace=dynamic-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/CreatureApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/CreatureApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,56 +10,77 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetCreatureFamiliesIndexAsync_Gets_CreatureFamiliesIndex()
         {
             ICreatureApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<CreatureFamiliesIndex> result = await warcraftClient.GetCreatureFamiliesIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/creature-family/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetCreatureFamilyAsync_Gets_CreatureFamily()
         {
             ICreatureApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<CreatureFamily> result = await warcraftClient.GetCreatureFamilyAsync(1, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/creature-family/1?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetCreatureTypesIndexAsync_Gets_CreatureTypesIndex()
         {
             ICreatureApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<CreatureTypesIndex> result = await warcraftClient.GetCreatureTypesIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/creature-type/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetCreatureTypeAsync_Gets_CreatureType()
         {
             ICreatureApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<CreatureType> result = await warcraftClient.GetCreatureTypeAsync(1, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/creature-type/1?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetCreatureAsync_Gets_Creature()
         {
             ICreatureApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<Creature> result = await warcraftClient.GetCreatureAsync(42722, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/creature/42722?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetCreatureDisplayMediaAsync_Gets_CreatureDisplayMedia()
         {
             ICreatureApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<CreatureDisplayMedia> result = await warcraftClient.GetCreatureDisplayMediaAsync(30221, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/media/creature-display/30221?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetCreatureFamilyMediaAsync_Gets_CreatureFamilyMedia()
         {
             ICreatureApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<CreatureFamilyMedia> result = await warcraftClient.GetCreatureFamilyMediaAsync(1, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/media/creature-family/1?namespace=static-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/GuildCrestApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/GuildCrestApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,24 +10,33 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetGuildCrestComponentsIndexAsync_Gets_GuildCrestComponentsIndex()
         {
             IGuildCrestApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<GuildCrestComponentsIndex> result = await warcraftClient.GetGuildCrestComponentsIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/guild-crest/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetGuildCrestBorderMediaAsync_Gets_GuildCrestBorderMedia()
         {
             IGuildCrestApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<GuildCrestBorderMedia> result = await warcraftClient.GetGuildCrestBorderMediaAsync(0, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/media/guild-crest/border/0?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetGuildCrestEmblemMediaAsync_Gets_GuildCrestEmblemMedia()
         {
             IGuildCrestApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<GuildCrestEmblemMedia> result = await warcraftClient.GetGuildCrestEmblemMediaAsync(0, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/media/guild-crest/emblem/0?namespace=static-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/ItemApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/ItemApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,56 +10,77 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetItemClassesIndexAsync_Gets_ItemClassesIndex()
         {
             IItemApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<ItemClassesIndex> result = await warcraftClient.GetItemClassesIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/item-class/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetItemClassAsync_Gets_ItemClass()
         {
             IItemApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<ItemClass> result = await warcraftClient.GetItemClassAsync(0, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/item-class/0?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetItemSetsIndexAsync_Gets_ItemSetsIndex()
         {
             IItemApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<ItemSetsIndex> result = await warcraftClient.GetItemSetsIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/item-set/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetItemSetAsync_Gets_ItemSet()
         {
             IItemApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<ItemSet> result = await warcraftClient.GetItemSetAsync(1, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/item-set/1?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetItemSubclassAsync_Gets_ItemSubclass()
         {
             IItemApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<ItemSubclass> result = await warcraftClient.GetItemSubclassAsync(0, 0, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/item-class/0/item-subclass/0?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetItemAsync_Gets_Item()
         {
             IItemApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<Item> result = await warcraftClient.GetItemAsync(19019, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/item/19019?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetItemMediaAsync_Gets_Item()
         {
             IItemApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<ItemMedia> result = await warcraftClient.GetItemMediaAsync(19019, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/media/item/19019?namespace=static-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/JournalApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/JournalApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,56 +10,77 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetJournalExpansionsIndexAsync_Gets_JournalExpansions()
         {
             IJournalApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<JournalExpansionsIndex> result = await warcraftClient.GetJournalExpansionsIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/journal-expansion/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetJournalExpansionAsync_Gets_JournalExpansion()
         {
             IJournalApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<JournalExpansion> result = await warcraftClient.GetJournalExpansionAsync(68, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/journal-expansion/68?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetJournalEncountersIndexAsync_Gets_JournalEncounters()
         {
             IJournalApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<JournalEncountersIndex> result = await warcraftClient.GetJournalEncountersIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/journal-encounter/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetJournalEncounterAsync_Gets_Encounter()
         {
             IJournalApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<Encounter> result = await warcraftClient.GetJournalEncounterAsync(89, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/journal-encounter/89?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetJournalInstancesIndexAsync_Gets_JournalInstances()
         {
             IJournalApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<JournalInstancesIndex> result = await warcraftClient.GetJournalInstancesIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/journal-instance/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetJournalInstanceAsync_Gets_Instance()
         {
             IJournalApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<Instance> result = await warcraftClient.GetJournalInstanceAsync(63, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/journal-instance/63?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetJournalInstanceMediaAsync_Gets_InstanceMedia()
         {
             IJournalApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<JournalInstanceMedia> result = await warcraftClient.GetJournalInstanceMediaAsync(63, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/media/journal-instance/63?namespace=static-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/ModifiedCraftingApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/ModifiedCraftingApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,40 +10,55 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetModifiedCraftingIndexAsync_Gets_ModifiedCraftingIndex()
         {
             IModifiedCraftingApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<ModifiedCraftingIndex> result = await warcraftClient.GetModifiedCraftingIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/modified-crafting/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetModifiedCraftingCategoryIndexAsync_Gets_ModifiedCraftingCategoryIndex()
         {
             IModifiedCraftingApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<ModifiedCraftingCategoryIndex> result = await warcraftClient.GetModifiedCraftingCategoryIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/modified-crafting/category/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetModifiedCraftingCategoryAsync_Gets_ModifiedCraftingCategory()
         {
             IModifiedCraftingApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<ModifiedCraftingCategory> result = await warcraftClient.GetModifiedCraftingCategoryAsync(1, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/modified-crafting/category/1?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetModifiedCraftingReagentSlotTypeIndexAsync_Gets_ModifiedCraftingReagentSlotTypeIndex()
         {
             IModifiedCraftingApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<ModifiedCraftingReagentSlotTypeIndex> result = await warcraftClient.GetModifiedCraftingReagentSlotTypeIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/modified-crafting/reagent-slot-type/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetModifiedCraftingReagentSlotTypeAsync_Gets_ModifiedCraftingReagentSlotType()
         {
             IModifiedCraftingApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<ModifiedCraftingReagentSlotType> result = await warcraftClient.GetModifiedCraftingReagentSlotTypeAsync(16, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/modified-crafting/reagent-slot-type/16?namespace=static-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/MountApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/MountApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,16 +10,22 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetMountsIndexAsync_Gets_MountsIndex()
         {
             IMountApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<MountsIndex> result = await warcraftClient.GetMountsIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/mount/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetMountAsync_Gets_Mount()
         {
             IMountApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<Mount> result = await warcraftClient.GetMountAsync(6, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/mount/6?namespace=static-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/MythicKeystoneAffixApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/MythicKeystoneAffixApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,24 +10,33 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetMythicKeystoneLeaderboardsIndexAsync_Gets_MythicKeystoneLeaderboardsIndex()
         {
             IMythicKeystoneAffixApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<MythicKeystoneAffixesIndex> result = await warcraftClient.GetMythicKeystoneAffixesIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/keystone-affix/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetMythicKeystoneAffixAsync_Gets_MythicKeystoneAffix()
         {
             IMythicKeystoneAffixApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<MythicKeystoneAffix> result = await warcraftClient.GetMythicKeystoneAffixAsync(1, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/keystone-affix/1?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetMythicKeystoneAffixMediaAsync_Gets_MythicKeystoneAffixMedia()
         {
             IMythicKeystoneAffixApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<MythicKeystoneAffixMedia> result = await warcraftClient.GetMythicKeystoneAffixMediaAsync(1, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/media/keystone-affix/1?namespace=static-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/MythicKeystoneDungeonApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/MythicKeystoneDungeonApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,56 +10,77 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetMythicKeystoneDungeonsIndexAsync_Gets_MythicKeystoneDungeonsIndex()
         {
             IMythicKeystoneDungeonApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<MythicKeystoneDungeonsIndex> result = await warcraftClient.GetMythicKeystoneDungeonsIndexAsync("dynamic-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/mythic-keystone/dungeon/index?namespace=dynamic-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetMythicKeystoneDungeonAsync_Gets_MythicKeystoneDungeon()
         {
             IMythicKeystoneDungeonApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<MythicKeystoneDungeon> result = await warcraftClient.GetMythicKeystoneDungeonAsync(375, "dynamic-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/mythic-keystone/dungeon/375?namespace=dynamic-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetMythicKeystoneIndexAsync_Gets_MythicKeystoneIndex()
         {
             IMythicKeystoneDungeonApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<MythicKeystoneIndex> result = await warcraftClient.GetMythicKeystoneIndexAsync("dynamic-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/mythic-keystone/index?namespace=dynamic-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetMythicKeystonePeriodsIndexAsync_Gets_MythicKeystonePeriodsIndex()
         {
             IMythicKeystoneDungeonApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<MythicKeystonePeriodsIndex> result = await warcraftClient.GetMythicKeystonePeriodsIndexAsync("dynamic-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/mythic-keystone/period/index?namespace=dynamic-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetMythicKeystonePeriodAsync_Gets_MythicKeystonePeriod()
         {
             IMythicKeystoneDungeonApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<MythicKeystonePeriod> result = await warcraftClient.GetMythicKeystonePeriodAsync(641, "dynamic-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/mythic-keystone/period/641?namespace=dynamic-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetMythicKeystoneSeasonsIndexAsync_Gets_MythicKeystoneSeasonsIndex()
         {
             IMythicKeystoneDungeonApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<MythicKeystoneSeasonsIndex> result = await warcraftClient.GetMythicKeystoneSeasonsIndexAsync("dynamic-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/mythic-keystone/season/index?namespace=dynamic-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetMythicKeystoneSeasonAsync_Gets_MythicKeystoneSeason()
         {
             IMythicKeystoneDungeonApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<MythicKeystoneSeason> result = await warcraftClient.GetMythicKeystoneSeasonAsync(1, "dynamic-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/mythic-keystone/season/1?namespace=dynamic-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/MythicKeystoneLeaderboardApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/MythicKeystoneLeaderboardApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,16 +10,22 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetMythicKeystoneLeaderboardsIndexAsync_Gets_MythicKeystoneLeaderboardsIndex()
         {
             IMythicKeystoneLeaderboardApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<MythicKeystoneLeaderboardsIndex> result = await warcraftClient.GetMythicKeystoneLeaderboardsIndexAsync(11, "dynamic-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/connected-realm/11/mythic-leaderboard/index?namespace=dynamic-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetMythicKeystoneLeaderboard_Gets_MythicKeystoneLeaderboard()
         {
             IMythicKeystoneLeaderboardApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<MythicKeystoneLeaderboard> result = await warcraftClient.GetMythicKeystoneLeaderboard(11, 197, 641, "dynamic-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/connected-realm/11/mythic-leaderboard/197/period/641?namespace=dynamic-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/MythicRaidLeaderboardApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/MythicRaidLeaderboardApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,8 +10,11 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetMythicKeystoneLeaderboardsIndexAsync_Gets_MythicKeystoneLeaderboardsIndex()
         {
             IMythicRaidLeaderboardApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<MythicRaidLeaderboard> result = await warcraftClient.GetMythicRaidLeaderboardAsync("uldir", "alliance", "dynamic-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/leaderboard/hall-of-fame/uldir/alliance?namespace=dynamic-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PetApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PetApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,40 +10,55 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetPetsIndexAsync_Gets_PetsIndex()
         {
             IPetApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<PetsIndex> result = await warcraftClient.GetPetsIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/pet/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetPetAsync_Gets_Pet()
         {
             IPetApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<Pet> result = await warcraftClient.GetPetAsync(39, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/pet/39?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetPetAbilitiesIndexAsync_Gets_PetAbilitiesIndex()
         {
             IPetApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<PetAbilitiesIndex> result = await warcraftClient.GetPetAbilitiesIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/pet-ability/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetPetAbilityAsync_Gets_PetAbility()
         {
             IPetApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<PetAbility> result = await warcraftClient.GetPetAbilityAsync(110, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/pet-ability/110?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetPetAbilityMediaAsync_Gets_PetAbilityMedia()
         {
             IPetApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<PetAbilityMedia> result = await warcraftClient.GetPetAbilityMediaAsync(110, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/media/pet-ability/110?namespace=static-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PlayableClassApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PlayableClassApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,32 +10,44 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetPlayableClassesIndexAsync_Gets_PlayableClassesIndex()
         {
             IPlayableClassApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<PlayableClassesIndex> result = await warcraftClient.GetPlayableClassesIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/playable-class/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetPlayableClassAsync_Gets_PlayableClass()
         {
             IPlayableClassApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<PlayableClass> result = await warcraftClient.GetPlayableClassAsync(7, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/playable-class/7?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetPlayableClassMediaAsync_Gets_PlayableClassMedia()
         {
             IPlayableClassApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<PlayableClassMedia> result = await warcraftClient.GetPlayableClassMediaAsync(7, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/media/playable-class/7?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetPvpTalentSlotsAsync_Gets_PvpTalentSlots()
         {
             IPlayableClassApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<PvpTalentSlots> result = await warcraftClient.GetPvpTalentSlotsAsync(7, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/playable-class/7/pvp-talent-slots?namespace=static-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PlayableRaceApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PlayableRaceApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,16 +10,22 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetPlayableRacesIndexAsync_Gets_PlayableRacesIndex()
         {
             IPlayableRaceApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<PlayableRacesIndex> result = await warcraftClient.GetPlayableRacesIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/playable-race/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetPlayableRaceAsync_Gets_PlayableRace()
         {
             IPlayableRaceApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<PlayableRace> result = await warcraftClient.GetPlayableRaceAsync(2, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/playable-race/2?namespace=static-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PlayableSpecializationApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PlayableSpecializationApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,24 +10,33 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetPlayableSpecializationsIndexAsync_Gets_PlayableSpecializationsIndex()
         {
             IPlayableSpecializationApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<PlayableSpecializationsIndex> result = await warcraftClient.GetPlayableSpecializationsIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/playable-specialization/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetPlayableSpecializationAsync_Gets_PlayableSpecialization()
         {
             IPlayableSpecializationApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<PlayableSpecialization> result = await warcraftClient.GetPlayableSpecializationAsync(262, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/playable-specialization/262?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetPlayableSpecializationMediaAsync_Gets_PlayableSpecializationMedia()
         {
             IPlayableSpecializationApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<PlayableSpecializationMedia> result = await warcraftClient.GetPlayableSpecializationMediaAsync(262, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/media/playable-specialization/262?namespace=static-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PowerTypeApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PowerTypeApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,16 +10,22 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetPowerTypesIndexAsync_Gets_PowerTypesIndex()
         {
             IPowerTypeApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<PowerTypesIndex> result = await warcraftClient.GetPowerTypesIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/power-type/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetPowerTypeAsync_Gets_PowerType()
         {
             IPowerTypeApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<PowerType> result = await warcraftClient.GetPowerTypeAsync(0, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/power-type/0?namespace=static-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/ProfessionApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/ProfessionApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,48 +10,66 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetProfessionsIndexAsync_Gets_ProfessionsIndex()
         {
             IProfessionApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<ProfessionsIndex> result = await warcraftClient.GetProfessionsIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/profession/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetProfessionAsync_Gets_Profession()
         {
             IProfessionApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<Profession> result = await warcraftClient.GetProfessionAsync(164, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/profession/164?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetProfessionMediaAsync_Gets_ProfessionMedia()
         {
             IProfessionApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<ProfessionMedia> result = await warcraftClient.GetProfessionMediaAsync(164, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/media/profession/164?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetSkillTierAsync_Gets_SkillTier()
         {
             IProfessionApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<SkillTier> result = await warcraftClient.GetSkillTierAsync(164, 2477, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/profession/164/skill-tier/2477?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetRecipeAsync_Gets_Recipe()
         {
             IProfessionApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<Recipe> result = await warcraftClient.GetRecipeAsync(1631, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/recipe/1631?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetRecipeMediaAsync_Gets_RecipeMedia()
         {
             IProfessionApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<RecipeMedia> result = await warcraftClient.GetRecipeMediaAsync(1631, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/media/recipe/1631?namespace=static-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PvpSeasonApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PvpSeasonApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,40 +10,55 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetPvpSeasonsIndexAsync_Gets_PvpSeasonsIndex()
         {
             IPvpSeasonApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<PvpSeasonsIndex> result = await warcraftClient.GetPvpSeasonsIndexAsync("dynamic-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/pvp-season/index?namespace=dynamic-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetPvpSeasonAsync_Gets_PvpSeason()
         {
             IPvpSeasonApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<PvpSeason> result = await warcraftClient.GetPvpSeasonAsync(27, "dynamic-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/pvp-season/27?namespace=dynamic-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetPvpLeaderboardsIndexAsync_Gets_PvpLeaderboardsIndex()
         {
             IPvpSeasonApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<PvpLeaderboardsIndex> result = await warcraftClient.GetPvpLeaderboardsIndexAsync(27, "dynamic-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/pvp-season/27/pvp-leaderboard/index?namespace=dynamic-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetPvpLeaderboardAsync_Gets_PvpLeaderboard()
         {
             IPvpSeasonApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<PvpLeaderboard> result = await warcraftClient.GetPvpLeaderboardAsync(27, "3v3", "dynamic-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/pvp-season/27/pvp-leaderboard/3v3?namespace=dynamic-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetPvpRewardsIndexAsync_Gets_PvpRewardsIndex()
         {
             IPvpSeasonApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<PvpRewardsIndex> result = await warcraftClient.GetPvpRewardsIndexAsync(27, "dynamic-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/pvp-season/27/pvp-reward/index?namespace=dynamic-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PvpTierApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PvpTierApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,24 +10,33 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetPvpTiersIndexAsync_Gets_PvpTiersIndex()
         {
             IPvpTierApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<PvpTiersIndex> result = await warcraftClient.GetPvpTiersIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/pvp-tier/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetPvpTierAsync_Gets_PvpTier()
         {
             IPvpTierApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<PvpTier> result = await warcraftClient.GetPvpTierAsync(1, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/pvp-tier/1?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetPvpTierMediaAsync_Gets_PvpTierMedia()
         {
             IPvpTierApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<PvpTierMedia> result = await warcraftClient.GetPvpTierMediaAsync(1, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/media/pvp-tier/1?namespace=static-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/QuestApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/QuestApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,64 +10,88 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetQuestsIndexAsync_Gets_QuestsIndex()
         {
             IQuestApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<QuestsIndex> result = await warcraftClient.GetQuestsIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/quest/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetQuestAsync_Gets_Quest()
         {
             IQuestApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<Quest> result = await warcraftClient.GetQuestAsync(2, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/quest/2?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetQuestCategoriesIndexAsync_Gets_QuestCategoriesIndex()
         {
             IQuestApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<QuestCategoriesIndex> result = await warcraftClient.GetQuestCategoriesIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/quest/category/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetQuestCategoryAsync_Gets_QuestCategory()
         {
             IQuestApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<QuestCategory> result = await warcraftClient.GetQuestCategoryAsync(1, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/quest/category/1?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetQuestAreasIndexAsync_Gets_QuestAreasIndex()
         {
             IQuestApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<QuestAreasIndex> result = await warcraftClient.GetQuestAreasIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/quest/area/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetQuestAreaAsync_Gets_QuestArea()
         {
             IQuestApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<QuestArea> result = await warcraftClient.GetQuestAreaAsync(1, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/quest/area/1?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetQuestTypesIndexAsync_Gets_QuestTypesIndex()
         {
             IQuestApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<QuestTypesIndex> result = await warcraftClient.GetQuestTypesIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/quest/type/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetQuestTypeAsync_Gets_QuestType()
         {
             IQuestApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<QuestType> result = await warcraftClient.GetQuestTypeAsync(1, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/quest/type/1?namespace=static-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/RealmApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/RealmApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,16 +10,22 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetPlayableRacesIndexAsync_Gets_PlayableRacesIndex()
         {
             IRealmApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<RealmsIndex> result = await warcraftClient.GetRealmsIndexAsync("dynamic-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/realm/index?namespace=dynamic-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetRealmAsync_Gets_Realm()
         {
             IRealmApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<Realm> result = await warcraftClient.GetRealmAsync("tichondrius", "dynamic-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/realm/tichondrius?namespace=dynamic-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/RegionApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/RegionApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,16 +10,22 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetRegionsIndexAsync_Gets_RegionsIndex()
         {
             IRegionApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<RegionsIndex> result = await warcraftClient.GetRegionsIndexAsync("dynamic-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/region/index?namespace=dynamic-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetRegionAsync_Gets_Region()
         {
             IRegionApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<RegionData> result = await warcraftClient.GetRegionAsync(1, "dynamic-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/region/1?namespace=dynamic-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/ReputationsApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/ReputationsApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,32 +10,44 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetReputationFactionsIndexAsync_Gets_ReputationFactionsIndex()
         {
             IReputationsApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<ReputationFactionsIndex> result = await warcraftClient.GetReputationFactionsIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/reputation-faction/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetReputationFactionAsync_Gets_ReputationFaction()
         {
             IReputationsApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<ReputationFaction> result = await warcraftClient.GetReputationFactionAsync(21, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/reputation-faction/21?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetReputationTiersIndexAsync_Gets_ReputationTiersIndex()
         {
             IReputationsApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<ReputationTiersIndex> result = await warcraftClient.GetReputationTiersIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/reputation-tiers/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetReputationTiersAsync_Gets_ReputationTiers()
         {
             IReputationsApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<ReputationTiers> result = await warcraftClient.GetReputationTiersAsync(2, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/reputation-tiers/2?namespace=static-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/SpellApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/SpellApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,16 +10,22 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetSpellAsync_Gets_Spell()
         {
             ISpellApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<Spell> result = await warcraftClient.GetSpellAsync(196607, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/spell/196607?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetSpellMediaAsync_Gets_SpellMedia()
         {
             ISpellApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<SpellMedia> result = await warcraftClient.GetSpellMediaAsync(196607, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/media/spell/196607?namespace=static-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/TalentApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/TalentApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,32 +10,44 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetTalentsIndexAsync_Gets_TalentsIndex()
         {
             ITalentApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<TalentsIndex> result = await warcraftClient.GetTalentsIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/talent/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetTalentAsync_Gets_Talent()
         {
             ITalentApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<Talent> result = await warcraftClient.GetTalentAsync(23106, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/talent/23106?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetPvpTalentsIndexAsync_Gets_PvpTalentsIndex()
         {
             ITalentApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<PvpTalentsIndex> result = await warcraftClient.GetPvpTalentsIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/pvp-talent/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetPvpTalentAsync_Gets_PvpTalent()
         {
             ITalentApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<PvpTalent> result = await warcraftClient.GetPvpTalentAsync(11, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/pvp-talent/11?namespace=static-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/TitleApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/TitleApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,16 +10,22 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetTitlesIndexAsync_Gets_TitlesIndex()
         {
             ITitleApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<TitlesIndex> result = await warcraftClient.GetTitlesIndexAsync("static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                            .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/title/index?namespace=static-us&locale=en_US");
         }
 
         [ResilientFact]
         public async Task GetTitleAsync_Gets_Title()
         {
             ITitleApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<Title> result = await warcraftClient.GetTitleAsync(1, "static-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                            .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/title/1?namespace=static-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/WowTokenApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/WowTokenApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Xunit;
+using ArgentPonyWarcraftClient.Integration.Tests.TestUtilities;
+using ArgentPonyWarcraftClient.Tests.Assertions;
 
 namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
 {
@@ -9,8 +10,11 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         public async Task GetWowTokenIndexAsync_Gets_WowTokenIndex()
         {
             IWowTokenApi warcraftClient = ClientFactory.BuildClient();
+
             RequestResult<WowTokenIndex> result = await warcraftClient.GetWowTokenIndexAsync("dynamic-us");
-            Assert.NotNull(result.Value);
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/token/index?namespace=dynamic-us&locale=en_US");
         }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Tests.Assertions/RequestResultAssertions.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests.Assertions/RequestResultAssertions.cs
@@ -9,6 +9,18 @@ namespace ArgentPonyWarcraftClient.Tests.Assertions
 {
     public class RequestResultAssertions<T> : ReferenceTypeAssertions<RequestResult<T>, RequestResultAssertions<T>>
     {
+        private static readonly JsonSerializerOptions s_jsonSerializerOptions;
+
+        /// <summary>
+        /// A static constructor for the <see cref="WarcraftClient"/> class.
+        /// </summary>
+        static RequestResultAssertions()
+        {
+            s_jsonSerializerOptions = new JsonSerializerOptions();
+            s_jsonSerializerOptions.Converters.Add(new EpochConverter());
+            s_jsonSerializerOptions.Converters.Add(new MillisecondTimeSpanConverter());
+        }
+
         public RequestResultAssertions(RequestResult<T> instance)
         {
             Subject = instance;
@@ -67,8 +79,9 @@ namespace ArgentPonyWarcraftClient.Tests.Assertions
             // exclude a property, e.g. { "cast_time": "Passive" } vs. { "cast_time": "Instant", "power_cost": null }
             NotBeNull();
 
-            var actualJsonValue = RemoveNullProperties(JObject.Parse(JsonSerializer.Serialize<T>(Subject.Value)));
-            var expectedJsonValue = RemoveNullProperties(JObject.Parse(expectedJson));
+            string actualJson = JsonSerializer.Serialize<T>(Subject.Value, s_jsonSerializerOptions);
+            JObject actualJsonValue = RemoveNullProperties(JObject.Parse(actualJson));
+            JObject expectedJsonValue = RemoveNullProperties(JObject.Parse(expectedJson));
 
             actualJsonValue.Should().BeEquivalentTo(expectedJsonValue);
         }

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
@@ -2506,12 +2506,6 @@ namespace ArgentPonyWarcraftClient.Tests.Properties {
         ///  },
         ///  &quot;slug&quot;: &quot;uldir-alliance&quot;,
         ///  &quot;criteria_type&quot;: &quot;hall-of-fame&quot;,
-        ///  &quot;zone&quot;: {
-        ///    &quot;key&quot;: {
-        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/zone/9389?namespace=static-us&quot;
-        ///    },
-        ///    &quot;name&quot;: &quot;Uldir&quot;
-        ///  },
         ///  &quot;entries&quot;: [
         ///    {
         ///      &quot;guild&quot;: {
@@ -2519,7 +2513,14 @@ namespace ArgentPonyWarcraftClient.Tests.Properties {
         ///        &quot;id&quot;: 31307591,
         ///        &quot;realm&quot;: {
         ///          &quot;name&quot;: &quot;Rhonin&quot;,
-        ///  [rest of string was truncated]&quot;;.
+        ///          &quot;id&quot;: 729,
+        ///          &quot;slug&quot;: &quot;rhonin&quot;
+        ///        }
+        ///      },
+        ///      &quot;faction&quot;: {
+        ///        &quot;type&quot;: &quot;ALLIANCE&quot;
+        ///      },
+        ///      &quot;timestamp&quot;: [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string MythicRaidLeaderboardResponse {
             get {

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
@@ -3435,14 +3435,14 @@ namespace ArgentPonyWarcraftClient.Tests.Properties {
         ///   Looks up a localized string similar to {
         ///  &quot;_links&quot;: {
         ///    &quot;self&quot;: {
-        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/quest/2?namespace=static-8.3.0_32861-us&quot;
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/quest/2?namespace=static-9.1.0_39069-us&quot;
         ///    }
         ///  },
         ///  &quot;id&quot;: 2,
         ///  &quot;title&quot;: &quot;Sharptalon&apos;s Claw&quot;,
         ///  &quot;area&quot;: {
         ///    &quot;key&quot;: {
-        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/quest/area/331?namespace=static-8.3.0_32861-us&quot;
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/quest/area/331?namespace=static-9.1.0_39069-us&quot;
         ///    },
         ///    &quot;name&quot;: &quot;Ashenvale&quot;,
         ///    &quot;id&quot;: 331

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
@@ -60811,12 +60811,6 @@
   },
   "slug": "uldir-alliance",
   "criteria_type": "hall-of-fame",
-  "zone": {
-    "key": {
-      "href": "https://us.api.blizzard.com/data/wow/zone/9389?namespace=static-us"
-    },
-    "name": "Uldir"
-  },
   "entries": [
     {
       "guild": {
@@ -60837,40 +60831,6 @@
     },
     {
       "guild": {
-        "name": "Honestly",
-        "id": 41321785,
-        "realm": {
-          "name": "Frostmourne",
-          "id": 3725,
-          "slug": "frostmourne"
-        }
-      },
-      "faction": {
-        "type": "ALLIANCE"
-      },
-      "timestamp": 1538129132000,
-      "region": "us",
-      "rank": 2
-    },
-    {
-      "guild": {
-        "name": "P G",
-        "id": 49912595,
-        "realm": {
-          "name": "Ravencrest",
-          "id": 554,
-          "slug": "ravencrest"
-        }
-      },
-      "faction": {
-        "type": "ALLIANCE"
-      },
-      "timestamp": 1538159395000,
-      "region": "eu",
-      "rank": 3
-    },
-    {
-      "guild": {
         "name": "Phoenix",
         "id": 40075794,
         "realm": {
@@ -60886,7 +60846,14 @@
       "region": "eu",
       "rank": 100
     }
-  ]
+  ],
+  "journal_instance": {
+    "key": {
+      "href": "https://us.api.blizzard.com/data/wow/journal-instance/1031?namespace=static-us"
+    },
+    "name": "Uldir",
+    "id": 1031
+  }
 }</value>
   </data>
   <data name="MythicKeystoneAffixesIndexResponse" xml:space="preserve">

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
@@ -62019,35 +62019,34 @@
     <value>{
   "_links": {
     "self": {
-      "href": "https://us.api.blizzard.com/data/wow/quest/2?namespace=static-8.3.0_32861-us"
+      "href": "https://us.api.blizzard.com/data/wow/quest/2?namespace=static-9.1.0_39069-us"
     }
   },
   "id": 2,
   "title": "Sharptalon's Claw",
   "area": {
     "key": {
-      "href": "https://us.api.blizzard.com/data/wow/quest/area/331?namespace=static-8.3.0_32861-us"
+      "href": "https://us.api.blizzard.com/data/wow/quest/area/331?namespace=static-9.1.0_39069-us"
     },
     "name": "Ashenvale",
     "id": 331
   },
   "description": "The mighty hippogryph Sharptalon has been slain, with the claw of the felled beast serving as a testament to your victory.\n\nSenani Thunderheart at the Silverwind Refuge will no doubt be interested in seeing this trophy as proof of your deeds.",
-  "recommended_minimum_level": 15,
-  "recommended_maximum_level": 60,
   "requirements": {
-    "min_character_level": 15,
+    "min_character_level": 7,
+    "max_character_level": 30,
     "faction": {
       "type": "HORDE",
       "name": "Horde"
     }
   },
   "rewards": {
-    "experience": 6300,
+    "experience": 4100,
     "reputations": [
       {
         "reward": {
           "key": {
-            "href": "https://us.api.blizzard.com/data/wow/reputation-faction/76?namespace=static-8.3.0_32861-us"
+            "href": "https://us.api.blizzard.com/data/wow/reputation-faction/76?namespace=static-9.1.0_39069-us"
           },
           "name": "Orgrimmar",
           "id": 76
@@ -62056,10 +62055,10 @@
       }
     ],
     "money": {
-      "value": 9000,
+      "value": 105000,
       "units": {
-        "gold": 0,
-        "silver": 90,
+        "gold": 10,
+        "silver": 50,
         "copper": 0
       }
     }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "6.2-alpha",
+  "version": "7.0-alpha",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/release/v\\d+(?:\\.\\d+){0,3}$",


### PR DESCRIPTION
Improved all integration tests for the Game Data API by using the test utilities for deep comparison.  Also updated model types that were discovered to have issues as a result of these improvements.  These are breaking changes, so I'm also updating the **version.json** to bump the major version.  

* Added a new `AssetWithoutFileDataId` class and updated the `Assets` property of `CreatureDisplayMedia` to use it since the non-nullable `FileDataId` does not appear to be returned with for this type.
* Fixed guild crest model types.  Added a `Colors` property to `GuildCrestComponentsIndex` with a new `GuildCrestColors` model type to support it.  Updated `GuildCrestBorderMedia` and `GuildCrestEmblemMedia` to use `AssetWithoutFileDataId` instead of `Asset` for their `Assets` properties.
* Added a `PurchaseQuantity` property to the `Item` model class.
* Updated `JournalMedia` to use `AssetWithoutFileDataId` instead of `Asset` for the `Assets` property.
* Fixed the `Mount` model type.  Added a `Requirements` property with a new `MountRequirements` model type to support it.
* Fixed mythic raid leaderboard model types.  Replaced the `Zone` property of the `MythicRaidLeaderBoard` model class with a `JournalInstance` property.
* Fixed pet model types.  Added a missing `Media` property to `Pet` with a new `PetMediaReference` model type to support it.
* Fixed quest model types.  Added a missing `MaxCharacterLevel` property to `QuestRequirements`.  Removed the `RecommendedMinimumLevel` and `RecommendedMaximumLevel` properties from `Quest`.

Fixed `RequestResultAssertions` serialization options to use the same converters used by `WarcraftClient` for consistency.  This is important to ensure that `TimeSpan` and `DateTimeOffset` properties round-trip properly.