### PR TITLE
Fixed recipe models

### DIFF
--- a/src/ArgentPonyWarcraftClient/ArgentPonyWarcraftClient.csproj
+++ b/src/ArgentPonyWarcraftClient/ArgentPonyWarcraftClient.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <None Include="docs/ArgentPony.png" Pack="true" PackagePath="\" />
-    <None Include="docs/README.md" Pack="true" PackagePath="\"/>
+    <None Include="docs/README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/ModifiedCrafting/ModifiedCraftingReagentSlotTypeReferenceWithoutName.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/ModifiedCrafting/ModifiedCraftingReagentSlotTypeReferenceWithoutName.cs
@@ -1,0 +1,22 @@
+﻿using System.Text.Json.Serialization;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// A Modified Crafting reagent slot type.
+    /// </summary>
+    public record ModifiedCraftingReagentSlotTypeReferenceWithoutName
+    {
+        /// <summary>
+        /// Gets the key for the Modified Crafting reagent slot type.
+        /// </summary>
+        [JsonPropertyName("key")]
+        public Self Key { get; init; }
+
+        /// <summary>
+        /// Gets the ID of the Modified Crafting reagent slot type.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public int Id { get; init; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Profession/CraftedQuantity.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Profession/CraftedQuantity.cs
@@ -5,18 +5,27 @@ namespace ArgentPonyWarcraftClient
     /// <summary>
     /// A range of item quantities produced by a recipe.
     /// </summary>
+    /// <remarks>
+    /// The crafted quantity will either have a value for <see cref="Value"/> or for <see cref="Minimum"/> and <see cref="Maximum"/>.
+    /// </remarks>
     public record CraftedQuantity
     {
         /// <summary>
         /// Gets the minimum number of the item produced.
         /// </summary>
         [JsonPropertyName("minimum")]
-        public float Minimum { get; init; }
+        public float? Minimum { get; init; }
 
         /// <summary>
         /// Gets the maximum number of the item produced.
         /// </summary>
         [JsonPropertyName("maximum")]
-        public float Maximum { get; init; }
+        public float? Maximum { get; init; }
+
+        /// <summary>
+        /// Gets the exact number of the item produced.
+        /// </summary>
+        [JsonPropertyName("value")]
+        public float? Value { get; init; }
     }
 }

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Profession/ModifiedCraftingSlot.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Profession/ModifiedCraftingSlot.cs
@@ -1,0 +1,22 @@
+﻿using System.Text.Json.Serialization;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// A Modified Crafting slot.
+    /// </summary>
+    public record ModifiedCraftingSlot
+    {
+        /// <summary>
+        /// Gets the slot type of the Modified Crafting slot.
+        /// </summary>
+        [JsonPropertyName("slot_type")]
+        public ModifiedCraftingReagentSlotTypeReferenceWithoutName SlotType { get; init; }
+
+        /// <summary>
+        /// Gets the display order of the Modified Crafting slot.
+        /// </summary>
+        [JsonPropertyName("display_order")]
+        public int DisplayOrder { get; init; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Profession/Recipe.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Profession/Recipe.cs
@@ -44,6 +44,18 @@ namespace ArgentPonyWarcraftClient
         public ItemReference CraftedItem { get; init; }
 
         /// <summary>
+        /// Gets a reference to the Alliance version of the item crafted by this recipe.
+        /// </summary>
+        [JsonPropertyName("alliance_crafted_item")]
+        public ItemReference AllianceCraftedItem { get; init; }
+
+        /// <summary>
+        /// Gets a reference to the Horde version of the item crafted by this recipe.
+        /// </summary>
+        [JsonPropertyName("horde_crafted_item")]
+        public ItemReference HordeCraftedItem { get; init; }
+
+        /// <summary>
         /// Gets the reagents required for the recipe.
         /// </summary>
         [JsonPropertyName("reagents")]
@@ -54,5 +66,11 @@ namespace ArgentPonyWarcraftClient
         /// </summary>
         [JsonPropertyName("crafted_quantity")]
         public CraftedQuantity CraftedQuantity { get; init; }
+
+        /// <summary>
+        /// Gets the modified crafting slots for this recipe.
+        /// </summary>
+        [JsonPropertyName("modified_crafting_slots")]
+        public ModifiedCraftingSlot[] ModifiedCraftingSlots { get; init; }
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/ProfessionApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/ProfessionApiTests.cs
@@ -62,6 +62,17 @@ namespace ArgentPonyWarcraftClient.Integration.Tests.GameDataApi
         }
 
         [ResilientFact]
+        public async Task GetRecipeAsync_Gets_Recipe_WithFactionSpecificItems()
+        {
+            IProfessionApi warcraftClient = ClientFactory.BuildClient();
+
+            RequestResult<Recipe> result = await warcraftClient.GetRecipeAsync(38729, "static-us");
+
+            await result.Should().BeSuccessfulRequest()
+                .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/recipe/38729?namespace=static-us&locale=en_US");
+        }
+
+        [ResilientFact]
         public async Task GetRecipeMediaAsync_Gets_RecipeMedia()
         {
             IProfessionApi warcraftClient = ClientFactory.BuildClient();

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/ProfessionApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/ProfessionApiTests.cs
@@ -62,6 +62,17 @@ namespace ArgentPonyWarcraftClient.Tests.GameDataApi
         }
 
         [Fact]
+        public async Task GetRecipeAsync_Gets_Recipe_WithFactionSpecificItems()
+        {
+            IProfessionApi warcraftClient = ClientFactory.BuildMockClient(
+                requestUri: "https://us.api.blizzard.com/data/wow/recipe/38729?namespace=static-us&locale=en_US",
+                responseContent: Resources.RecipeWithFactionSpecificItemsResponse);
+
+            RequestResult<Recipe> result = await warcraftClient.GetRecipeAsync(38729, "static-us");
+            Assert.NotNull(result.Value);
+        }
+
+        [Fact]
         public async Task GetRecipeMediaAsync_Gets_RecipeMedia()
         {
             IProfessionApi warcraftClient = ClientFactory.BuildMockClient(

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
@@ -3646,6 +3646,32 @@ namespace ArgentPonyWarcraftClient.Tests.Properties {
         ///   Looks up a localized string similar to {
         ///  &quot;_links&quot;: {
         ///    &quot;self&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/recipe/38729?namespace=static-9.1.0_39069-us&quot;
+        ///    }
+        ///  },
+        ///  &quot;id&quot;: 38729,
+        ///  &quot;name&quot;: &quot;Monel-Hardened Boots&quot;,
+        ///  &quot;description&quot;: &quot;Create Monel-Hardened Boots.&quot;,
+        ///  &quot;media&quot;: {
+        ///    &quot;key&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/media/recipe/38729?namespace=static-9.1.0_39069-us&quot;
+        ///    },
+        ///    &quot;id&quot;: 38729
+        ///  },
+        ///  &quot;alliance_crafted_item&quot;: {
+        ///    &quot;key&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/item/1 [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string RecipeWithFactionSpecificItemsResponse {
+            get {
+                return ResourceManager.GetString("RecipeWithFactionSpecificItemsResponse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {
+        ///  &quot;_links&quot;: {
+        ///    &quot;self&quot;: {
         ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/region/1?namespace=dynamic-us&quot;
         ///    }
         ///  },

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
@@ -79884,4 +79884,72 @@
   ]
 }</value>
   </data>
+  <data name="RecipeWithFactionSpecificItemsResponse" xml:space="preserve">
+    <value>{
+  "_links": {
+    "self": {
+      "href": "https://us.api.blizzard.com/data/wow/recipe/38729?namespace=static-9.1.0_39069-us"
+    }
+  },
+  "id": 38729,
+  "name": "Monel-Hardened Boots",
+  "description": "Create Monel-Hardened Boots.",
+  "media": {
+    "key": {
+      "href": "https://us.api.blizzard.com/data/wow/media/recipe/38729?namespace=static-9.1.0_39069-us"
+    },
+    "id": 38729
+  },
+  "alliance_crafted_item": {
+    "key": {
+      "href": "https://us.api.blizzard.com/data/wow/item/161881?namespace=static-9.1.0_39069-us"
+    },
+    "name": "Monel-Hardened Boots",
+    "id": 161881
+  },
+  "horde_crafted_item": {
+    "key": {
+      "href": "https://us.api.blizzard.com/data/wow/item/152803?namespace=static-9.1.0_39069-us"
+    },
+    "name": "Monel-Hardened Boots",
+    "id": 152803
+  },
+  "reagents": [
+    {
+      "reagent": {
+        "key": {
+          "href": "https://us.api.blizzard.com/data/wow/item/152512?namespace=static-9.1.0_39069-us"
+        },
+        "name": "Monelite Ore",
+        "id": 152512
+      },
+      "quantity": 14
+    },
+    {
+      "reagent": {
+        "key": {
+          "href": "https://us.api.blizzard.com/data/wow/item/160298?namespace=static-9.1.0_39069-us"
+        },
+        "name": "Durable Flux",
+        "id": 160298
+      },
+      "quantity": 2
+    }
+  ],
+  "crafted_quantity": {
+    "value": 1
+  },
+  "modified_crafting_slots": [
+    {
+      "slot_type": {
+        "key": {
+          "href": "https://us.api.blizzard.com/data/wow/modified-crafting/reagent-slot-type/47?namespace=static-9.1.0_39069-us"
+        },
+        "id": 47
+      },
+      "display_order": 0
+    }
+  ]
+}</value>
+  </data>
 </root>


### PR DESCRIPTION
Fixed recipe models.  Added `AllianceCraftedItem` and `HordeCraftedItem` properties for recipes that produce faction-specific items.  Added a `ModifiedCraftingSlots` property for recipes that allow modified crafting.  Added a supporting `ModifiedCraftingSlot` model type.  Updated the `CraftedQuantity` model type to add a `Value` property and made the existing `Minimum` and `Maximum` properties nullable since they are not always present.  Added new tests to ensure these cases are tested.

Resolves #197.