### PR TITLE
GitHub Actions build improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
 
     - name: Install .NET 5 SDK
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@53063334342b67eb3f5066a7ac9151683aa30b96 # v1.8.1
       with:
-        dotnet-version: 5.0.201
+        dotnet-version: 5.0.302
 
     - name: Build
       run: dotnet build --configuration Release --verbosity minimal
@@ -30,7 +30,7 @@ jobs:
         BLIZZARD_CLIENT_SECRET: ${{ secrets.BLIZZARD_CLIENT_SECRET }}
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074 # v2.2.4
       with:
         name: NuGet packages
         path: |
@@ -43,7 +43,7 @@ jobs:
 
     - name: Create GitHub Release
       if: ${{ startsWith(github.ref, 'refs/tags/v') }} # Only for a tag
-      uses: actions/create-release@v1
+      uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
GitHub Actions build improvements.  Updated all references to actions to use the git commit SHA to securely reference a fixed version.  Also updated the .NET 5 SDK version from 5.0.201 to 5.0.302 (current latest).