### PR TITLE
Updated NuGet packages and GitHub Actions build steps

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "nbgv": {
-      "version": "3.4.220",
+      "version": "3.4.244",
       "commands": [
         "nbgv"
       ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+      uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
 
     - name: Install .NET 5 SDK
-      uses: actions/setup-dotnet@53063334342b67eb3f5066a7ac9151683aa30b96 # v1.8.1
+      uses: actions/setup-dotnet@5a3fa01c67e60dba8f95e2878436c7151c4b5f01 # v1.8.2
       with:
-        dotnet-version: 5.0.302
+        dotnet-version: 5.0.402
 
     - name: Build
       run: dotnet build --configuration Release --verbosity minimal

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Artifacts" Version="2.2.0" PrivateAssets="all" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.244" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests.csproj
+++ b/tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests.csproj
@@ -12,7 +12,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.0.3">
+        <PackageReference Include="coverlet.collector" Version="3.1.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests.csproj
+++ b/tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
           <PrivateAssets>all</PrivateAssets>

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/ArgentPonyWarcraftClient.Integration.Tests.csproj
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/ArgentPonyWarcraftClient.Integration.Tests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.2.0" />
-    <PackageReference Include="FluentAssertions.Json" Version="5.5.0" />
+    <PackageReference Include="FluentAssertions.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/ArgentPonyWarcraftClient.Integration.Tests.csproj
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/ArgentPonyWarcraftClient.Integration.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="6.2.0" />
     <PackageReference Include="FluentAssertions.Json" Version="5.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/ArgentPonyWarcraftClient.Integration.Tests.csproj
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/ArgentPonyWarcraftClient.Integration.Tests.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="FluentAssertions.Json" Version="5.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/ArgentPonyWarcraftClient.Tests.Assertions/ArgentPonyWarcraftClient.Tests.Assertions.csproj
+++ b/tests/ArgentPonyWarcraftClient.Tests.Assertions/ArgentPonyWarcraftClient.Tests.Assertions.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="6.2.0" />
     <PackageReference Include="FluentAssertions.Json" Version="5.5.0" />
   </ItemGroup>
   

--- a/tests/ArgentPonyWarcraftClient.Tests.Assertions/ArgentPonyWarcraftClient.Tests.Assertions.csproj
+++ b/tests/ArgentPonyWarcraftClient.Tests.Assertions/ArgentPonyWarcraftClient.Tests.Assertions.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.2.0" />
-    <PackageReference Include="FluentAssertions.Json" Version="5.5.0" />
+    <PackageReference Include="FluentAssertions.Json" Version="6.0.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/tests/ArgentPonyWarcraftClient.Tests.Assertions/RequestResultAssertions.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests.Assertions/RequestResultAssertions.cs
@@ -21,9 +21,9 @@ namespace ArgentPonyWarcraftClient.Tests.Assertions
             s_jsonSerializerOptions.Converters.Add(new MillisecondTimeSpanConverter());
         }
 
-        public RequestResultAssertions(RequestResult<T> instance)
+        public RequestResultAssertions(RequestResult<T> subject)
+            : base(subject)
         {
-            Subject = instance;
         }
 
         /// <inheritdoc />

--- a/tests/ArgentPonyWarcraftClient.Tests/ArgentPonyWarcraftClient.Tests.csproj
+++ b/tests/ArgentPonyWarcraftClient.Tests/ArgentPonyWarcraftClient.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
* Updated the [Microsoft.NET.Test.Sdk](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/) NuGet package from 16.10.0 to 17.0.0.
* Updated the [FluentAssertions](https://www.nuget.org/packages/FluentAssertions/) NuGet package from 5.10.3 to 6.2.0.  This required a small change to the `RequestResultAssertions` class due to constructor changes in the base `ReferenceTypeAssertions` class.
* Updated the [FluentAssertions.Json](https://www.nuget.org/packages/FluentAssertions.Json/) NuGet package from 5.5.0 to 6.0.0.
* Updated the [coverlet.collector](https://www.nuget.org/packages/coverlet.collector/) NuGet package from 3.0.3 to 3.1.0.
* Updated the [Nerdbank.GitVersioning](https://www.nuget.org/packages/Nerdbank.GitVersioning/) NuGet package and associated [nbgv](https://www.nuget.org/packages/nbgv/) .NET tool from 3.4.220 to 3.4.244.
* Updated GitHub Actions build steps, updating all action references to the latest available and updating the version of the [.NET 5 SDK](https://dotnet.microsoft.com/download/dotnet/5.0) from 5.0.302 to 5.0.402.