### PR TITLE
Fixes for Dragonflight 

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "nbgv": {
-      "version": "3.4.244",
+      "version": "3.5.119",
       "commands": [
         "nbgv"
       ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
 
     - name: Install .NET 7 SDK
-      uses: actions/setup-dotnet@5a3fa01c67e60dba8f95e2878436c7151c4b5f01 # v1.8.2
+      uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
       with:
         dotnet-version: 7.0.103
 
@@ -30,7 +30,7 @@ jobs:
         BLIZZARD_CLIENT_SECRET: ${{ secrets.BLIZZARD_CLIENT_SECRET }}
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074 # v2.2.4
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: NuGet packages
         path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,10 @@ jobs:
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
 
-    - name: Install .NET 5 SDK
+    - name: Install .NET 7 SDK
       uses: actions/setup-dotnet@5a3fa01c67e60dba8f95e2878436c7151c4b5f01 # v1.8.2
       with:
-        dotnet-version: 6.0.100
+        dotnet-version: 7.0.103
 
     - name: Build
       run: dotnet build --configuration Release --verbosity minimal

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Artifacts" Version="2.2.0" PrivateAssets="all" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.244" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Artifacts" Version="4.2.0" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.119" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100",
+    "version": "7.0.103",
     "rollForward": "latestMinor"
   }
 }

--- a/src/ArgentPonyWarcraftClient.Extensions.DependencyInjection/ArgentPonyWarcraftClient.Extensions.DependencyInjection.csproj
+++ b/src/ArgentPonyWarcraftClient.Extensions.DependencyInjection/ArgentPonyWarcraftClient.Extensions.DependencyInjection.csproj
@@ -15,8 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ArgentPonyWarcraftClient/ArgentPonyWarcraftClient.csproj
+++ b/src/ArgentPonyWarcraftClient/ArgentPonyWarcraftClient.csproj
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.0" PrivateAssets="All" />
-    <PackageReference Include="System.Text.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="System.Text.Json" Version="7.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/AuctionHouse/AuctionsIndex.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/AuctionHouse/AuctionsIndex.cs
@@ -22,4 +22,10 @@ public record AuctionsIndex
     /// </summary>
     [JsonPropertyName("auctions")]
     public Auction[] Auctions { get; init; }
+
+    /// <summary>
+    /// Gets commodities associated with the auctions.
+    /// </summary>
+    [JsonPropertyName("commodities")]
+    public Self Commodities { get; init; }
 }

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Item/PreviewItem.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Item/PreviewItem.cs
@@ -12,6 +12,18 @@ public record PreviewItem
     public Media Item { get; init; }
 
     /// <summary>
+    /// Gets the context for the item.
+    /// </summary>
+    [JsonPropertyName("context")]
+    public int Context { get; init; }
+
+    /// <summary>
+    /// Gets the bonus list for the item.
+    /// </summary>
+    [JsonPropertyName("bonus_list")]
+    public int[] BonusList { get; init; }
+
+    /// <summary>
     /// Gets the quality of the item.
     /// </summary>
     [JsonPropertyName("quality")]

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/MythicKeystoneDungeon/MythicKeystoneDungeon.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/MythicKeystoneDungeon/MythicKeystoneDungeon.cs
@@ -46,4 +46,10 @@ public record MythicKeystoneDungeon
     /// </summary>
     [JsonPropertyName("keystone_upgrades")]
     public MythicKeystoneUpgrade[] KeystoneUpgrades { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the mythic keystone dungeon is tracked.
+    /// </summary>
+    [JsonPropertyName("is_tracked")]
+    public bool IsTracked { get; init; }
 }

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/PlayableSpecialization/PlayableSpecialization.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/PlayableSpecialization/PlayableSpecialization.cs
@@ -58,4 +58,10 @@ public record PlayableSpecialization
     /// </summary>
     [JsonPropertyName("pvp_talents")]
     public PvpTalentElement[] PvpTalents { get; init; }
+
+    /// <summary>
+    /// Gets a reference to the talent tree associated with this specialization.
+    /// </summary>
+    [JsonPropertyName("spec_talent_tree")]
+    public TalentTreeReference SpecTalentTree { get; init; }
 }

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Talent/RankDescription.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Talent/RankDescription.cs
@@ -1,0 +1,19 @@
+﻿namespace ArgentPonyWarcraftClient;
+
+/// <summary>
+/// A talent rank description.
+/// </summary>
+public record RankDescription
+{
+    /// <summary>
+    /// Gets the numeric rank.
+    /// </summary>
+    [JsonPropertyName("rank")]
+    public int Rank { get; init; }
+
+    /// <summary>
+    /// Gets the rank description.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string Description { get; init; }
+}

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Talent/Talent.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Talent/Talent.cs
@@ -18,22 +18,10 @@ public record Talent
     public int Id { get; init; }
 
     /// <summary>
-    /// Gets the tier index for the talent.
+    /// Gets the rank description associated with this talent.
     /// </summary>
-    [JsonPropertyName("tier_index")]
-    public int TierIndex { get; init; }
-
-    /// <summary>
-    /// Gets the column index of the talent.
-    /// </summary>
-    [JsonPropertyName("column_index")]
-    public int ColumnIndex { get; init; }
-
-    /// <summary>
-    /// Gets the level of the talent.
-    /// </summary>
-    [JsonPropertyName("level")]
-    public int Level { get; init; }
+    [JsonPropertyName("rank_descriptions")]
+    public RankDescription[] RankDescription { get; init; }
 
     /// <summary>
     /// Gets the description of the talent.
@@ -52,4 +40,10 @@ public record Talent
     /// </summary>
     [JsonPropertyName("playable_class")]
     public PlayableClassReference PlayableClass { get; init; }
+
+    /// <summary>
+    /// Gets a reference to the playable specialization associated with this talent.
+    /// </summary>
+    [JsonPropertyName("playable_specialization")]
+    public PlayableSpecializationReference PlayableSpecialization { get; init; }
 }

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Talent/TalentTreeReference.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Talent/TalentTreeReference.cs
@@ -1,0 +1,19 @@
+﻿namespace ArgentPonyWarcraftClient;
+
+/// <summary>
+/// A reference to a talent tree.
+/// </summary>
+public record TalentTreeReference
+{
+    /// <summary>
+    /// Gets the key for the talent tree.
+    /// </summary>
+    [JsonPropertyName("key")]
+    public Self Key { get; init; }
+
+    /// <summary>
+    /// Gets the name of the talent tree.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; init; }
+}

--- a/tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests.csproj
+++ b/tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests.csproj
@@ -7,13 +7,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="3.2.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests.csproj
+++ b/tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests/ArgentPonyWarcraftClient.Extensions.DependencyInjection.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/ArgentPonyWarcraftClient.Integration.Tests.csproj
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/ArgentPonyWarcraftClient.Integration.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/ArgentPonyWarcraftClient.Integration.Tests.csproj
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/ArgentPonyWarcraftClient.Integration.Tests.csproj
@@ -11,11 +11,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.2.0" />
-    <PackageReference Include="FluentAssertions.Json" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="FluentAssertions" Version="6.10.0" />
+    <PackageReference Include="FluentAssertions.Json" Version="6.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/MythicKeystoneDungeonApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/MythicKeystoneDungeonApiTests.cs
@@ -18,10 +18,10 @@ public class MythicKeystoneDungeonApiTests
     {
         IMythicKeystoneDungeonApi warcraftClient = ClientFactory.BuildClient();
 
-        RequestResult<MythicKeystoneDungeon> result = await warcraftClient.GetMythicKeystoneDungeonAsync(375, "dynamic-us");
+        RequestResult<MythicKeystoneDungeon> result = await warcraftClient.GetMythicKeystoneDungeonAsync(197, "dynamic-us");
 
         await result.Should().BeSuccessfulRequest()
-            .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/mythic-keystone/dungeon/375?namespace=dynamic-us&locale=en_US");
+            .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/mythic-keystone/dungeon/197?namespace=dynamic-us&locale=en_US");
     }
 
     [ResilientFact]

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/TalentApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/TalentApiTests.cs
@@ -18,10 +18,10 @@ public class TalentApiTests
     {
         ITalentApi warcraftClient = ClientFactory.BuildClient();
 
-        RequestResult<Talent> result = await warcraftClient.GetTalentAsync(23106, "static-us");
+        RequestResult<Talent> result = await warcraftClient.GetTalentAsync(117163, "static-us");
 
         await result.Should().BeSuccessfulRequest()
-            .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/talent/23106?namespace=static-us&locale=en_US");
+            .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/talent/117163?namespace=static-us&locale=en_US");
     }
 
     [ResilientFact]

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterPvpApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/ProfileApi/CharacterPvpApiTests.cs
@@ -8,7 +8,7 @@ public class CharacterPvpApiTests
     public async Task GetCharacterPvpBracketStatisticsAsync_Gets_PvpBracketStatistics()
     {
         ICharacterPvpApi warcraftClient = ClientFactory.BuildClient();
-        RequestResult<CharacterPvpBracketStatistics> result = await warcraftClient.GetCharacterPvpBracketStatisticsAsync("malganis", "zenli", "3v3", "profile-us");
+        RequestResult<CharacterPvpBracketStatistics> result = await warcraftClient.GetCharacterPvpBracketStatisticsAsync("malganis", "gutso", "3v3", "profile-us");
         Assert.NotNull(result.Value);
     }
 
@@ -16,7 +16,7 @@ public class CharacterPvpApiTests
     public async Task GetCharacterPvpSummaryAsync_Gets_CharacterPvpSummary()
     {
         ICharacterPvpApi warcraftClient = ClientFactory.BuildClient();
-        RequestResult<CharacterPvpSummary> result = await warcraftClient.GetCharacterPvpSummaryAsync("malganis", "zenli", "profile-us");
+        RequestResult<CharacterPvpSummary> result = await warcraftClient.GetCharacterPvpSummaryAsync("malganis", "gutso", "profile-us");
         Assert.NotNull(result.Value);
     }
 }

--- a/tests/ArgentPonyWarcraftClient.Tests.Assertions/ArgentPonyWarcraftClient.Tests.Assertions.csproj
+++ b/tests/ArgentPonyWarcraftClient.Tests.Assertions/ArgentPonyWarcraftClient.Tests.Assertions.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.2.0" />
-    <PackageReference Include="FluentAssertions.Json" Version="6.0.0" />
+    <PackageReference Include="FluentAssertions" Version="6.10.0" />
+    <PackageReference Include="FluentAssertions.Json" Version="6.1.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/tests/ArgentPonyWarcraftClient.Tests/ArgentPonyWarcraftClient.Tests.csproj
+++ b/tests/ArgentPonyWarcraftClient.Tests/ArgentPonyWarcraftClient.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/tests/ArgentPonyWarcraftClient.Tests/ArgentPonyWarcraftClient.Tests.csproj
+++ b/tests/ArgentPonyWarcraftClient.Tests/ArgentPonyWarcraftClient.Tests.csproj
@@ -11,10 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/MythicKeystoneDungeonApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/MythicKeystoneDungeonApiTests.cs
@@ -17,10 +17,10 @@ public class MythicKeystoneDungeonApiTests
     public async Task GetMythicKeystoneDungeonAsync_Gets_MythicKeystoneDungeon()
     {
         IMythicKeystoneDungeonApi warcraftClient = ClientFactory.BuildMockClient(
-            requestUri: "https://us.api.blizzard.com/data/wow/mythic-keystone/dungeon/353?namespace=dynamic-us&locale=en_US",
+            requestUri: "https://us.api.blizzard.com/data/wow/mythic-keystone/dungeon/197?namespace=dynamic-us&locale=en_US",
             responseContent: Resources.MythicKeystoneDungeonResponse);
 
-        RequestResult<MythicKeystoneDungeon> result = await warcraftClient.GetMythicKeystoneDungeonAsync(353, "dynamic-us");
+        RequestResult<MythicKeystoneDungeon> result = await warcraftClient.GetMythicKeystoneDungeonAsync(197, "dynamic-us");
         Assert.NotNull(result.Value);
     }
 

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/TalentApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/TalentApiTests.cs
@@ -17,10 +17,10 @@ public class TalentApiTests
     public async Task GetTalentAsync_Gets_Talent()
     {
         ITalentApi warcraftClient = ClientFactory.BuildMockClient(
-            requestUri: "https://us.api.blizzard.com/data/wow/talent/23106?namespace=static-us&locale=en_US",
+            requestUri: "https://us.api.blizzard.com/data/wow/talent/117163?namespace=static-us&locale=en_US",
             responseContent: Resources.TalentResponse);
 
-        RequestResult<Talent> result = await warcraftClient.GetTalentAsync(23106, "static-us");
+        RequestResult<Talent> result = await warcraftClient.GetTalentAsync(117163, "static-us");
         Assert.NotNull(result.Value);
     }
 

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
@@ -2266,25 +2266,26 @@ namespace ArgentPonyWarcraftClient.Tests.Properties {
         ///   Looks up a localized string similar to {
         ///  &quot;_links&quot;: {
         ///    &quot;self&quot;: {
-        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/mythic-keystone/dungeon/353?namespace=dynamic-us&quot;
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/mythic-keystone/dungeon/197?namespace=dynamic-us&quot;
         ///    }
         ///  },
-        ///  &quot;id&quot;: 353,
-        ///  &quot;name&quot;: &quot;Siege of Boralus&quot;,
+        ///  &quot;id&quot;: 197,
+        ///  &quot;name&quot;: &quot;Eye of Azshara&quot;,
         ///  &quot;map&quot;: {
-        ///    &quot;name&quot;: &quot;Siege of Boralus&quot;,
-        ///    &quot;id&quot;: 1822
+        ///    &quot;name&quot;: &quot;Eye of Azshara&quot;,
+        ///    &quot;id&quot;: 1456
         ///  },
         ///  &quot;zone&quot;: {
-        ///    &quot;slug&quot;: &quot;siege-of-boralus&quot;
+        ///    &quot;slug&quot;: &quot;eye-of-azshara&quot;
         ///  },
         ///  &quot;dungeon&quot;: {
         ///    &quot;key&quot;: {
-        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/journal-instance/1023?namespace=static-8.3.0_32861-us&quot;
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/journal-instance/716?namespace=static-10.0.5_47621-us&quot;
         ///    },
-        ///    &quot;name&quot;: &quot;Siege of Boralus&quot;,
-        ///    &quot;id&quot;: 1023
-        ///  },        /// [rest of string was truncated]&quot;;.
+        ///    &quot;name&quot;: &quot;Eye of Azshara&quot;,
+        ///    &quot;id&quot;: 716
+        ///  },
+        ///  &quot;keyst [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string MythicKeystoneDungeonResponse {
             get {

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
@@ -1728,7 +1728,7 @@ namespace ArgentPonyWarcraftClient.Tests.Properties {
         ///   Looks up a localized string similar to {
         ///  &quot;_links&quot;: {
         ///    &quot;self&quot;: {
-        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/item/19019?namespace=static-8.3.0_32861-us&quot;
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/item/19019?namespace=static-10.0.5_47621-us&quot;
         ///    }
         ///  },
         ///  &quot;id&quot;: 19019,
@@ -1737,15 +1737,15 @@ namespace ArgentPonyWarcraftClient.Tests.Properties {
         ///    &quot;type&quot;: &quot;LEGENDARY&quot;,
         ///    &quot;name&quot;: &quot;Legendary&quot;
         ///  },
-        ///  &quot;level&quot;: 58,
-        ///  &quot;required_level&quot;: 60,
+        ///  &quot;level&quot;: 29,
+        ///  &quot;required_level&quot;: 25,
         ///  &quot;media&quot;: {
         ///    &quot;key&quot;: {
-        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/media/item/19019?namespace=static-8.3.0_32861-us&quot;
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/media/item/19019?namespace=static-10.0.5_47621-us&quot;
         ///    },
         ///    &quot;id&quot;: 19019
         ///  },
-        ///  &quot;item_class&quot;: {        /// [rest of string was truncated]&quot;;.
+        ///  &quot;item_class&quot;:  [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ItemResponse {
             get {

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace ArgentPonyWarcraftClient.Tests.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -3948,19 +3948,21 @@ namespace ArgentPonyWarcraftClient.Tests.Properties {
         ///   Looks up a localized string similar to {
         ///  &quot;_links&quot;: {
         ///    &quot;self&quot;: {
-        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/talent/23106?namespace=static-8.3.0_32861-us&quot;
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/talent/117163?namespace=static-10.0.5_47621-us&quot;
         ///    }
         ///  },
-        ///  &quot;id&quot;: 23106,
-        ///  &quot;tier_index&quot;: 0,
-        ///  &quot;column_index&quot;: 0,
-        ///  &quot;level&quot;: 15,
-        ///  &quot;description&quot;: &quot;Tiger Palm also applies Eye of the Tiger, dealing 168 Nature damage to the enemy and 168 healing to the Monk over 8 sec.&quot;,
+        ///  &quot;id&quot;: 117163,
+        ///  &quot;rank_descriptions&quot;: [
+        ///    {
+        ///      &quot;rank&quot;: 1,
+        ///      &quot;description&quot;: &quot;Revenge deals 10% more damage, or 20% more damage when your successful dodges or parries have made it cost no Rage.&quot;
+        ///    }
+        ///  ],
         ///  &quot;spell&quot;: {
         ///    &quot;key&quot;: {
-        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/spell/196607?namespace=static-8.3.0_32861-us&quot;
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/spell/202560?namespace=static-10.0.5_47621-us&quot;
         ///    },
-        ///    &quot;name&quot;: &quot;Eye [rest of string was truncated]&quot;;.
+        ///    &quot;nam [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string TalentResponse {
             get {

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
@@ -2822,20 +2822,21 @@ namespace ArgentPonyWarcraftClient.Tests.Properties {
         ///   Looks up a localized string similar to {
         ///  &quot;_links&quot;: {
         ///    &quot;self&quot;: {
-        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/playable-specialization/262?namespace=static-8.3.0_32861-us&quot;
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/talent/117163?namespace=static-10.0.5_47621-us&quot;
         ///    }
         ///  },
-        ///  &quot;id&quot;: 262,
-        ///  &quot;playable_class&quot;: {
+        ///  &quot;id&quot;: 117163,
+        ///  &quot;rank_descriptions&quot;: [
+        ///    {
+        ///      &quot;rank&quot;: 1,
+        ///      &quot;description&quot;: &quot;Revenge deals 10% more damage, or 20% more damage when your successful dodges or parries have made it cost no Rage.&quot;
+        ///    }
+        ///  ],
+        ///  &quot;spell&quot;: {
         ///    &quot;key&quot;: {
-        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/playable-class/7?namespace=static-8.3.0_32861-us&quot;
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/spell/202560?namespace=static-10.0.5_47621-us&quot;
         ///    },
-        ///    &quot;name&quot;: &quot;Shaman&quot;,
-        ///    &quot;id&quot;: 7
-        ///  },
-        ///  &quot;name&quot;: &quot;Elemental&quot;,
-        ///  &quot;gender_description&quot;: {
-        ///    &quot;male&quot;: &quot;A spellcaster who harnesses the destructive forces of nature and the elements.\r\n\r [rest of string was truncated]&quot;;.
+        ///    &quot;nam [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string PlayableSpecializationResponse {
             get {

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
@@ -61133,39 +61133,40 @@
     <value>{
   "_links": {
     "self": {
-      "href": "https://us.api.blizzard.com/data/wow/mythic-keystone/dungeon/353?namespace=dynamic-us"
+      "href": "https://us.api.blizzard.com/data/wow/mythic-keystone/dungeon/197?namespace=dynamic-us"
     }
   },
-  "id": 353,
-  "name": "Siege of Boralus",
+  "id": 197,
+  "name": "Eye of Azshara",
   "map": {
-    "name": "Siege of Boralus",
-    "id": 1822
+    "name": "Eye of Azshara",
+    "id": 1456
   },
   "zone": {
-    "slug": "siege-of-boralus"
+    "slug": "eye-of-azshara"
   },
   "dungeon": {
     "key": {
-      "href": "https://us.api.blizzard.com/data/wow/journal-instance/1023?namespace=static-8.3.0_32861-us"
+      "href": "https://us.api.blizzard.com/data/wow/journal-instance/716?namespace=static-10.0.5_47621-us"
     },
-    "name": "Siege of Boralus",
-    "id": 1023
+    "name": "Eye of Azshara",
+    "id": 716
   },
   "keystone_upgrades": [
     {
       "upgrade_level": 1,
-      "qualifying_duration": 2160000
+      "qualifying_duration": 2100000
     },
     {
       "upgrade_level": 2,
-      "qualifying_duration": 1728000
+      "qualifying_duration": 1680000
     },
     {
       "upgrade_level": 3,
-      "qualifying_duration": 1296000
+      "qualifying_duration": 1260000
     }
-  ]
+  ],
+  "is_tracked": false
 }</value>
   </data>
   <data name="MythicKeystoneIndexResponse" xml:space="preserve">

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
@@ -65393,193 +65393,37 @@
     <value>{
   "_links": {
     "self": {
-      "href": "https://us.api.blizzard.com/data/wow/playable-specialization/262?namespace=static-8.3.0_32861-us"
+      "href": "https://us.api.blizzard.com/data/wow/talent/117163?namespace=static-10.0.5_47621-us"
     }
   },
-  "id": 262,
-  "playable_class": {
-    "key": {
-      "href": "https://us.api.blizzard.com/data/wow/playable-class/7?namespace=static-8.3.0_32861-us"
-    },
-    "name": "Shaman",
-    "id": 7
-  },
-  "name": "Elemental",
-  "gender_description": {
-    "male": "A spellcaster who harnesses the destructive forces of nature and the elements.\r\n\r\nPreferred Weapon: Mace, Dagger, and Shield",
-    "female": "A spellcaster who harnesses the destructive forces of nature and the elements.\r\n\r\nPreferred Weapon: Mace, Dagger, and Shield"
-  },
-  "media": {
-    "key": {
-      "href": "https://us.api.blizzard.com/data/wow/media/playable-specialization/262?namespace=static-8.3.0_32861-us"
-    },
-    "id": 262
-  },
-  "role": {
-    "type": "DAMAGE",
-    "name": "Damage"
-  },
-  "talent_tiers": [
+  "id": 117163,
+  "rank_descriptions": [
     {
-      "level": 15,
-      "talents": [
-        {
-          "talent": {
-            "key": {
-              "href": "https://us.api.blizzard.com/data/wow/talent/22356?namespace=static-8.3.0_32861-us"
-            },
-            "name": "Earthen Rage",
-            "id": 22356
-          },
-          "spell_tooltip": {
-            "description": "Your damaging spells incite the earth around you to come to your aid for 6 sec, repeatedly dealing 833 Nature damage to your most recently attacked target.",
-            "cast_time": "Passive"
-          },
-          "column_index": 0
-        },
-        {
-          "talent": {
-            "key": {
-              "href": "https://us.api.blizzard.com/data/wow/talent/22357?namespace=static-8.3.0_32861-us"
-            },
-            "name": "Echo of the Elements",
-            "id": 22357
-          },
-          "spell_tooltip": {
-            "description": "Lava Burst now has 2 charges. Effects that reset its remaining cooldown will instead grant 1 charge.",
-            "cast_time": "Passive"
-          },
-          "column_index": 1
-        },
-        {
-          "talent": {
-            "key": {
-              "href": "https://us.api.blizzard.com/data/wow/talent/22358?namespace=static-8.3.0_32861-us"
-            },
-            "name": "Elemental Blast",
-            "id": 22358
-          },
-          "spell_tooltip": {
-            "description": "Harnesses the raw power of the elements, dealing 3,818 Elemental damage and increasing your Critical Strike, Haste, or Mastery by 366 for 10 sec.\r\n\r\nCan cause an Elemental Overload.",
-            "cast_time": "2 sec cast",
-            "range": "40 yd range",
-            "cooldown": "12 sec cooldown"
-          },
-          "column_index": 2
-        }
-      ],
-      "tier_index": 0
-    },
-    {
-      "level": 100,
-      "talents": [
-        {
-          "talent": {
-            "key": {
-              "href": "https://us.api.blizzard.com/data/wow/talent/21198?namespace=static-8.3.0_32861-us"
-            },
-            "name": "Unlimited Power",
-            "id": 21198
-          },
-          "spell_tooltip": {
-            "description": "When your spells cause an elemental overload, you gain 2% Haste for 10 sec. Gaining a stack does not refresh the duration.",
-            "cast_time": "Passive"
-          },
-          "column_index": 0
-        },
-        {
-          "talent": {
-            "key": {
-              "href": "https://us.api.blizzard.com/data/wow/talent/22153?namespace=static-8.3.0_32861-us"
-            },
-            "name": "Stormkeeper",
-            "id": 22153
-          },
-          "spell_tooltip": {
-            "description": "Charge yourself with lightning, causing your next 2 Lightning Bolts to deal 150% more damage, and also causes your next 2 Lightning Bolts or Chain Lightnings to be instant cast and trigger an Elemental Overload on every target.",
-            "cast_time": "1.5 sec cast",
-            "cooldown": "1 min cooldown"
-          },
-          "column_index": 1
-        },
-        {
-          "talent": {
-            "key": {
-              "href": "https://us.api.blizzard.com/data/wow/talent/21675?namespace=static-8.3.0_32861-us"
-            },
-            "name": "Ascendance",
-            "id": 21675
-          },
-          "spell_tooltip": {
-            "description": "Transform into a Flame Ascendant for 15 sec, replacing Chain Lightning with Lava Beam, removing the cooldown on Lava Burst, and increasing the damage of Lava Burst by an amount equal to your critical strike chance.",
-            "cast_time": "Instant",
-            "cooldown": "3 min cooldown"
-          },
-          "column_index": 2
-        }
-      ],
-      "tier_index": 6
+      "rank": 1,
+      "description": "Revenge deals 10% more damage, or 20% more damage when your successful dodges or parries have made it cost no Rage."
     }
   ],
-  "pvp_talents": [
-    {
-      "talent": {
-        "key": {
-          "href": "https://us.api.blizzard.com/data/wow/pvp-talent/727?namespace=static-8.3.0_32861-us"
-        },
-        "name": "Elemental Attunement",
-        "id": 727
-      },
-      "spell_tooltip": {
-        "description": "Increases your maximum Maelstrom by 50.",
-        "cast_time": "Passive"
-      }
+  "spell": {
+    "key": {
+      "href": "https://us.api.blizzard.com/data/wow/spell/202560?namespace=static-10.0.5_47621-us"
     },
-    {
-      "talent": {
-        "key": {
-          "href": "https://us.api.blizzard.com/data/wow/pvp-talent/3490?namespace=static-8.3.0_32861-us"
-        },
-        "name": "Counterstrike Totem",
-        "id": 3490
-      },
-      "spell_tooltip": {
-        "description": "Summons an Air Totem with 5 health at the feet of the caster for 15 sec. \r\n\r\nWhenever enemies within 20 yards of the totem deal direct damage, the totem will deal 100% of the damage dealt back to attacker. ",
-        "cast_time": "Instant",
-        "power_cost": "600 Mana",
-        "range": "40 yd range",
-        "cooldown": "45 sec cooldown"
-      }
+    "name": "Best Served Cold",
+    "id": 202560
+  },
+  "playable_class": {
+    "key": {
+      "href": "https://us.api.blizzard.com/data/wow/playable-class/1?namespace=static-10.0.5_47621-us"
     },
-    {
-      "talent": {
-        "key": {
-          "href": "https://us.api.blizzard.com/data/wow/pvp-talent/3620?namespace=static-8.3.0_32861-us"
-        },
-        "name": "Grounding Totem",
-        "id": 3620
-      },
-      "spell_tooltip": {
-        "description": "Summons an Air Totem with 5 health at the feet of the caster that will redirect all harmful spells cast on a nearby party or raid member to itself. Will not redirect area of effect spells. Lasts 3 sec.",
-        "cast_time": "Instant",
-        "power_cost": "1,180 Mana",
-        "cooldown": "30 sec cooldown"
-      }
+    "name": "Warrior",
+    "id": 1
+  },
+  "playable_specialization": {
+    "key": {
+      "href": "https://us.api.blizzard.com/data/wow/playable-specialization/73?namespace=static-10.0.5_47621-us"
     },
-    {
-      "talent": {
-        "key": {
-          "href": "https://us.api.blizzard.com/data/wow/pvp-talent/3621?namespace=static-8.3.0_32861-us"
-        },
-        "name": "Swelling Waves",
-        "id": 3621
-      },
-      "spell_tooltip": {
-        "description": "When you cast Healing Surge on yourself, you are healed for 50% of the amount 3 sec later.",
-        "cast_time": "Passive"
-      }
-    }
-  ]
+    "name": "Protection",
+    "id": 73
+  }
 }</value>
   </data>
   <data name="PlayableSpecializationsIndexResponse" xml:space="preserve">

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
@@ -54227,7 +54227,7 @@
     <value>{
   "_links": {
     "self": {
-      "href": "https://us.api.blizzard.com/data/wow/item/19019?namespace=static-8.3.0_32861-us"
+      "href": "https://us.api.blizzard.com/data/wow/item/19019?namespace=static-10.0.5_47621-us"
     }
   },
   "id": 19019,
@@ -54236,24 +54236,24 @@
     "type": "LEGENDARY",
     "name": "Legendary"
   },
-  "level": 58,
-  "required_level": 60,
+  "level": 29,
+  "required_level": 25,
   "media": {
     "key": {
-      "href": "https://us.api.blizzard.com/data/wow/media/item/19019?namespace=static-8.3.0_32861-us"
+      "href": "https://us.api.blizzard.com/data/wow/media/item/19019?namespace=static-10.0.5_47621-us"
     },
     "id": 19019
   },
   "item_class": {
     "key": {
-      "href": "https://us.api.blizzard.com/data/wow/item-class/2?namespace=static-8.3.0_32861-us"
+      "href": "https://us.api.blizzard.com/data/wow/item-class/2?namespace=static-10.0.5_47621-us"
     },
     "name": "Weapon",
     "id": 2
   },
   "item_subclass": {
     "key": {
-      "href": "https://us.api.blizzard.com/data/wow/item-class/2/item-subclass/7?namespace=static-8.3.0_32861-us"
+      "href": "https://us.api.blizzard.com/data/wow/item-class/2/item-subclass/7?namespace=static-10.0.5_47621-us"
     },
     "name": "Sword",
     "id": 7
@@ -54262,18 +54262,22 @@
     "type": "WEAPON",
     "name": "One-Hand"
   },
-  "purchase_price": 575526,
-  "sell_price": 115105,
+  "purchase_price": 162276,
+  "sell_price": 32455,
   "max_count": 1,
   "is_equippable": true,
   "is_stackable": false,
   "preview_item": {
     "item": {
       "key": {
-        "href": "https://us.api.blizzard.com/data/wow/item/19019?namespace=static-8.3.0_32861-us"
+        "href": "https://us.api.blizzard.com/data/wow/item/19019?namespace=static-10.0.5_47621-us"
       },
       "id": 19019
     },
+    "context": 0,
+    "bonus_list": [
+      9264
+    ],
     "quality": {
       "type": "LEGENDARY",
       "name": "Legendary"
@@ -54281,20 +54285,20 @@
     "name": "Thunderfury, Blessed Blade of the Windseeker",
     "media": {
       "key": {
-        "href": "https://us.api.blizzard.com/data/wow/media/item/19019?namespace=static-8.3.0_32861-us"
+        "href": "https://us.api.blizzard.com/data/wow/media/item/19019?namespace=static-10.0.5_47621-us"
       },
       "id": 19019
     },
     "item_class": {
       "key": {
-        "href": "https://us.api.blizzard.com/data/wow/item-class/2?namespace=static-8.3.0_32861-us"
+        "href": "https://us.api.blizzard.com/data/wow/item-class/2?namespace=static-10.0.5_47621-us"
       },
       "name": "Weapon",
       "id": 2
     },
     "item_subclass": {
       "key": {
-        "href": "https://us.api.blizzard.com/data/wow/item-class/2/item-subclass/7?namespace=static-8.3.0_32861-us"
+        "href": "https://us.api.blizzard.com/data/wow/item-class/2/item-subclass/7?namespace=static-10.0.5_47621-us"
       },
       "name": "Sword",
       "id": 7
@@ -54310,9 +54314,9 @@
     "unique_equipped": "Unique",
     "weapon": {
       "damage": {
-        "min_value": 16,
-        "max_value": 28,
-        "display_string": "16 - 28 Damage",
+        "min_value": 17,
+        "max_value": 30,
+        "display_string": "17 - 30 Damage",
         "damage_class": {
           "type": "PHYSICAL",
           "name": "Physical"
@@ -54323,8 +54327,8 @@
         "display_string": "Speed 2.60"
       },
       "dps": {
-        "value": 8.461538,
-        "display_string": "(8.5 damage per second)"
+        "value": 9.038461,
+        "display_string": "(9.0 damage per second)"
       }
     },
     "stats": [
@@ -54382,9 +54386,9 @@
           "type": "NATURE_RESISTANCE",
           "name": "Nature Resistance"
         },
-        "value": 5,
+        "value": 6,
         "display": {
-          "display_string": "+5 Nature Resistance",
+          "display_string": "+6 Nature Resistance",
           "color": {
             "r": 0,
             "g": 255,
@@ -54398,38 +54402,30 @@
       {
         "spell": {
           "key": {
-            "href": "https://us.api.blizzard.com/data/wow/spell/21992?namespace=static-8.3.0_32861-us"
+            "href": "https://us.api.blizzard.com/data/wow/spell/21992?namespace=static-10.0.5_47621-us"
           },
           "name": "Thunderfury",
           "id": 21992
         },
-        "description": "Chance on hit: Blasts your enemy with lightning, dealing 1,114 Nature damage and then jumping to additional nearby enemies.  Each jump reduces that victim's Nature resistance by 88. Affects 5 targets. Your primary target is also consumed by a cyclone, slowing its attack speed by 20% for 12 sec."
+        "description": "Chance on hit: Blasts your enemy with lightning, dealing 53 Nature damage and then jumping to additional nearby enemies.  Each jump reduces that victim's Nature resistance by 4. Affects 5 targets. Your primary target is also consumed by a cyclone, slowing its attack speed by 20% for 12 sec."
       }
     ],
-    "sell_price": {
-      "value": 115105,
-      "display_strings": {
-        "header": "Sell Price:",
-        "gold": "11",
-        "silver": "51",
-        "copper": "5"
-      }
-    },
     "requirements": {
       "level": {
-        "value": 60,
-        "display_string": "Requires Level 60"
+        "value": 30,
+        "display_string": "Requires Level 30"
       }
     },
     "level": {
-      "value": 58,
-      "display_string": "Item Level 58"
+      "value": 101,
+      "display_string": "Item Level 101"
     },
     "durability": {
       "value": 130,
       "display_string": "Durability 130 / 130"
     }
-  }
+  },
+  "purchase_quantity": 1
 }</value>
   </data>
   <data name="ItemMediaResponse" xml:space="preserve">

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
@@ -61505,27 +61505,36 @@
     <value>{
   "_links": {
     "self": {
-      "href": "https://us.api.blizzard.com/data/wow/talent/23106?namespace=static-8.3.0_32861-us"
+      "href": "https://us.api.blizzard.com/data/wow/talent/117163?namespace=static-10.0.5_47621-us"
     }
   },
-  "id": 23106,
-  "tier_index": 0,
-  "column_index": 0,
-  "level": 15,
-  "description": "Tiger Palm also applies Eye of the Tiger, dealing 168 Nature damage to the enemy and 168 healing to the Monk over 8 sec.",
+  "id": 117163,
+  "rank_descriptions": [
+    {
+      "rank": 1,
+      "description": "Revenge deals 10% more damage, or 20% more damage when your successful dodges or parries have made it cost no Rage."
+    }
+  ],
   "spell": {
     "key": {
-      "href": "https://us.api.blizzard.com/data/wow/spell/196607?namespace=static-8.3.0_32861-us"
+      "href": "https://us.api.blizzard.com/data/wow/spell/202560?namespace=static-10.0.5_47621-us"
     },
-    "name": "Eye of the Tiger",
-    "id": 196607
+    "name": "Best Served Cold",
+    "id": 202560
   },
   "playable_class": {
     "key": {
-      "href": "https://us.api.blizzard.com/data/wow/playable-class/10?namespace=static-8.3.0_32861-us"
+      "href": "https://us.api.blizzard.com/data/wow/playable-class/1?namespace=static-10.0.5_47621-us"
     },
-    "name": "Monk",
-    "id": 10
+    "name": "Warrior",
+    "id": 1
+  },
+  "playable_specialization": {
+    "key": {
+      "href": "https://us.api.blizzard.com/data/wow/playable-specialization/73?namespace=static-10.0.5_47621-us"
+    },
+    "name": "Protection",
+    "id": 73
   }
 }</value>
   </data>

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
@@ -54220,7 +54220,10 @@
       "quantity": 1,
       "time_left": "VERY_LONG"
     }
-  ]
+  ],
+  "commodities": {
+    "href": "https://us.api.blizzard.com/data/wow/auctions/commodities?namespace=dynamic-us"
+  }
 }</value>
   </data>
   <data name="ItemResponse" xml:space="preserve">

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "7.1-alpha",
+  "version": "8.0-alpha",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+(?:\\.\\d+){0,3}$",


### PR DESCRIPTION
Dusted off the tests for the Dragonflight expansion.  This is a first step for full support, just updating dependencies and getting all the integration tests working again after API changes and changes in the data.

- Updated the version in the **version.json** file to `8.0-alpha` for the 8.0 release for the Dragonflight expansion.
- Updated all unit test projects to .NET 7.  Updated the GitHub Actions build and **global.json** accordingly.
- Updated all NuGet packages to the latest available.
- Updated `AuctionsIndex`, `MythicKeystoneDungeon`, `PlayableSpecialization`, `PreviewItem`, and `Talent` along with related classes and tests based on the API and data changes for the Dragonflight expansion.
- Updated third party GitHub Actions to the latest versions.

