### PR TITLE
Dragonflight API support

### DIFF
--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/AuctionHouseApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/AuctionHouseApi.cs
@@ -14,4 +14,17 @@ public partial class WarcraftClient
         string host = GetHost(region);
         return await GetAsync<AuctionsIndex>($"{host}/data/wow/connected-realm/{connectedRealmId}/auctions?namespace={@namespace}&locale={locale}");
     }
+
+    /// <inheritdoc />
+    public async Task<RequestResult<CommoditiesIndex>> GetCommoditiesAsync(string @namespace)
+    {
+        return await GetCommoditiesAsync(@namespace, Region, Locale);
+    }
+
+    /// <inheritdoc />
+    public async Task<RequestResult<CommoditiesIndex>> GetCommoditiesAsync(string @namespace, Region region, Locale locale)
+    {
+        string host = GetHost(region);
+        return await GetAsync<CommoditiesIndex>($"{host}/data/wow/auctions/commodities?namespace={@namespace}&locale={locale}");
+    }
 }

--- a/src/ArgentPonyWarcraftClient/Client/GameDataApi/PetApi.cs
+++ b/src/ArgentPonyWarcraftClient/Client/GameDataApi/PetApi.cs
@@ -29,6 +29,19 @@ public partial class WarcraftClient
     }
 
     /// <inheritdoc />
+    public async Task<RequestResult<PetMedia>> GetPetMediaAsync(int petId, string @namespace)
+    {
+        return await GetPetMediaAsync(petId, @namespace, Region, Locale);
+    }
+
+    /// <inheritdoc />
+    public async Task<RequestResult<PetMedia>> GetPetMediaAsync(int petId, string @namespace, Region region, Locale locale)
+    {
+        string host = GetHost(region);
+        return await GetAsync<PetMedia>($"{host}/data/wow/media/pet/{petId}?namespace={@namespace}&locale={locale}");
+    }
+
+    /// <inheritdoc />
     public async Task<RequestResult<PetAbilitiesIndex>> GetPetAbilitiesIndexAsync(string @namespace)
     {
         return await GetPetAbilitiesIndexAsync(@namespace, Region, Locale);

--- a/src/ArgentPonyWarcraftClient/Interfaces/GameDataApi/IAuctionHouseApi.cs
+++ b/src/ArgentPonyWarcraftClient/Interfaces/GameDataApi/IAuctionHouseApi.cs
@@ -11,19 +11,39 @@ public interface IAuctionHouseApi
     /// <param name="connectedRealmId">The ID of the connected realm.</param>
     /// <param name="namespace">The namespace to use to locate this document.</param>
     /// <returns>
-    ///     The pet index.
+    ///     The auctions index.
     /// </returns>
     Task<RequestResult<AuctionsIndex>> GetAuctionsAsync(int connectedRealmId, string @namespace);
 
     /// <summary>
-    ///     Gets an index of pets.
+    ///     Gets an index of auctions.
     /// </summary>
     /// <param name="connectedRealmId">The ID of the connected realm.</param>
     /// <param name="namespace">The namespace to use to locate this document.</param>
     /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
     /// <param name="locale">Specifies the language that the result will be in.</param>
     /// <returns>
-    ///     The pet index.
+    ///     The auctions index.
     /// </returns>
     Task<RequestResult<AuctionsIndex>> GetAuctionsAsync(int connectedRealmId, string @namespace, Region region, Locale locale);
+
+    /// <summary>
+    ///     Gets an index of commodities.
+    /// </summary>
+    /// <param name="namespace">The namespace to use to locate this document.</param>
+    /// <returns>
+    ///     The commodities index.
+    /// </returns>
+    Task<RequestResult<CommoditiesIndex>> GetCommoditiesAsync(string @namespace);
+
+    /// <summary>
+    ///     Gets an index of commodities.
+    /// </summary>
+    /// <param name="namespace">The namespace to use to locate this document.</param>
+    /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+    /// <param name="locale">Specifies the language that the result will be in.</param>
+    /// <returns>
+    ///     The commodities index.
+    /// </returns>
+    Task<RequestResult<CommoditiesIndex>> GetCommoditiesAsync(string @namespace, Region region, Locale locale);
 }

--- a/src/ArgentPonyWarcraftClient/Interfaces/GameDataApi/IPetApi.cs
+++ b/src/ArgentPonyWarcraftClient/Interfaces/GameDataApi/IPetApi.cs
@@ -48,6 +48,28 @@ public interface IPetApi
     Task<RequestResult<Pet>> GetPetAsync(int petId, string @namespace, Region region, Locale locale);
 
     /// <summary>
+    ///     Get media for a pet by ID.
+    /// </summary>
+    /// <param name="petId">The pet ID.</param>
+    /// <param name="namespace">The namespace to use to locate this document.</param>
+    /// <returns>
+    ///     Media for a pet by ID.
+    /// </returns>
+    Task<RequestResult<PetMedia>> GetPetMediaAsync(int petId, string @namespace);
+
+    /// <summary>
+    ///     Get media for a pet by ID.
+    /// </summary>
+    /// <param name="petId">The pet ID.</param>
+    /// <param name="namespace">The namespace to use to locate this document.</param>
+    /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+    /// <param name="locale">Specifies the language that the result will be in.</param>
+    /// <returns>
+    ///     Media for a pet by ID.
+    /// </returns>
+    Task<RequestResult<PetMedia>> GetPetMediaAsync(int petId, string @namespace, Region region, Locale locale);
+
+    /// <summary>
     ///     Gets an index of pet abilities.
     /// </summary>
     /// <param name="namespace">The namespace to use to locate this document.</param>

--- a/src/ArgentPonyWarcraftClient/Interfaces/GameDataApi/ITalentApi.cs
+++ b/src/ArgentPonyWarcraftClient/Interfaces/GameDataApi/ITalentApi.cs
@@ -26,52 +26,55 @@ public interface ITalentApi
     Task<RequestResult<TalentTreeIndex>> GetTalentTreeIndexAsync(string @namespace, Region region, Locale locale);
 
     /// <summary>
-    ///     Get the specified talent tree by specialization Id.
+    ///     Get the specified talent tree by specialization ID.
     /// </summary>
-    /// <param name="talentTreeId">The id of the talent-tree.</param>
-    /// <param name="specId">The id of the playable-specialization.</param>
+    /// <param name="talentTreeId">The ID of the talent tree.</param>
+    /// <param name="specId">The ID of the playable specialization.</param>
     /// <param name="namespace">The namespace to use to locate this document.</param>
     /// <returns>
-    ///     The specified talent tree by specialization Id.
+    ///     The specified talent tree by specialization ID.
     /// </returns>
     Task<RequestResult<TalentTree>> GetTalentTreeAsync(int talentTreeId, int specId, string @namespace);
 
     /// <summary>
-    ///     Get the specified talent tree by specialization Id.
+    ///     Get the specified talent tree by specialization ID.
     /// </summary>
-    /// <param name="talentTreeId">The id of the talent-tree.</param>
-    /// <param name="specId">The id of the playable-specialization.</param>
+    /// <param name="talentTreeId">The ID of the talent tree.</param>
+    /// <param name="specId">The ID of the playable specialization.</param>
     /// <param name="namespace">The namespace to use to locate this document.</param>
     /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
     /// <param name="locale">Specifies the language that the result will be in.</param>
     /// <returns>
-    ///     The specified talent tree by specialization Id.
+    ///     The specified talent tree by specialization ID.
     /// </returns>
-
     Task<RequestResult<TalentTree>> GetTalentTreeAsync(int talentTreeId, int specId, string @namespace, Region region, Locale locale);
 
     /// <summary>
-    ///     Get all talent tree nodes as well as links to associated playable specializations given a talent tree id.
-    ///     This is useful to generate loadout export codes.
+    ///     Get all talent tree nodes as well as links to associated playable specializations given a talent tree ID.
     /// </summary>
-    /// <param name="talentTreeId">The id of the talent-tree.</param>
+    /// <param name="talentTreeId">The ID of the talent tree.</param>
     /// <param name="namespace">The namespace to use to locate this document.</param>
     /// <returns>
-    ///      All talent tree nodes as well as links to associated playable specializations given a talent tree id.
+    ///     All talent tree nodes as well as links to associated playable specializations given a talent tree ID.
     /// </returns>
+    /// <remarks>
+    ///     This is useful to generate loadout export codes.
+    /// </remarks>
     Task<RequestResult<TalentTreeNodes>> GetTalentTreeNodesAsync(int talentTreeId, string @namespace);
 
     /// <summary>
-    ///     Get all talent tree nodes as well as links to associated playable specializations given a talent tree id.
-    ///     This is useful to generate loadout export codes.
+    ///     Get all talent tree nodes as well as links to associated playable specializations given a talent tree ID.
     /// </summary>
-    /// <param name="talentTreeId">The id of the talent-tree.</param>
+    /// <param name="talentTreeId">The ID of the talent tree.</param>
     /// <param name="namespace">The namespace to use to locate this document.</param>
     /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
     /// <param name="locale">Specifies the language that the result will be in.</param>
     /// <returns>
-    ///     All talent tree nodes as well as links to associated playable specializations given a talent tree id.
+    ///     All talent tree nodes as well as links to associated playable specializations given a talent tree ID.
     /// </returns>
+    /// <remarks>
+    ///     This is useful to generate loadout export codes.
+    /// </remarks>
     Task<RequestResult<TalentTreeNodes>> GetTalentTreeNodesAsync(int talentTreeId, string @namespace, Region region, Locale locale);
 
     /// <summary>

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/AuctionHouse/CommoditiesIndex.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/AuctionHouse/CommoditiesIndex.cs
@@ -1,0 +1,19 @@
+﻿namespace ArgentPonyWarcraftClient;
+
+/// <summary>
+/// An index of commodities.
+/// </summary>
+public record CommoditiesIndex
+{
+    /// <summary>
+    /// Gets links for the index of commodities.
+    /// </summary>
+    [JsonPropertyName("_links")]
+    public Links Links { get; init; }
+
+    /// <summary>
+    /// Gets the auctions.
+    /// </summary>
+    [JsonPropertyName("auctions")]
+    public Commodity[] Auctions { get; init; }
+}

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/AuctionHouse/Commodity.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/AuctionHouse/Commodity.cs
@@ -1,0 +1,37 @@
+﻿namespace ArgentPonyWarcraftClient;
+
+/// <summary>
+/// A commodity.
+/// </summary>
+public record Commodity
+{
+    /// <summary>
+    /// Gets the ID of the commodity.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public int Id { get; init; }
+
+    /// <summary>
+    /// Gets the item being auctioned.
+    /// </summary>
+    [JsonPropertyName("item")]
+    public CommodityItem Item { get; init; }
+
+    /// <summary>
+    /// Gets the quantity of the item being auctioned.
+    /// </summary>
+    [JsonPropertyName("quantity")]
+    public int Quantity { get; init; }
+
+    /// <summary>
+    /// Gets the unit price of the item being auctioned.
+    /// </summary>
+    [JsonPropertyName("unit_price")]
+    public long? UnitPrice { get; init; }
+
+    /// <summary>
+    /// Gets the approximate time remaining for the auction (SHORT or VERY_LONG).
+    /// </summary>
+    [JsonPropertyName("time_left")]
+    public string TimeLeft { get; init; }
+}

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/AuctionHouse/CommodityItem.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/AuctionHouse/CommodityItem.cs
@@ -1,0 +1,13 @@
+﻿namespace ArgentPonyWarcraftClient;
+
+/// <summary>
+/// A commodity item.
+/// </summary>
+public record CommodityItem
+{
+    /// <summary>
+    /// Gets the ID of the commodity item.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public int Id { get; init; }
+}

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/Pet/PetMedia.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/Pet/PetMedia.cs
@@ -1,0 +1,25 @@
+﻿namespace ArgentPonyWarcraftClient;
+
+/// <summary>
+/// Pet media.
+/// </summary>
+public record PetMedia
+{
+    /// <summary>
+    /// Gets links for the pet media.
+    /// </summary>
+    [JsonPropertyName("_links")]
+    public Links Links { get; init; }
+
+    /// <summary>
+    /// Gets a collection of media assets.
+    /// </summary>
+    [JsonPropertyName("assets")]
+    public Asset[] Assets { get; init; }
+
+    /// <summary>
+    /// Gets the Id of the pet that the media belongs to.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public int Id { get; init; }
+}

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/TalentTree/TalentNodeRank.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/TalentTree/TalentNodeRank.cs
@@ -13,15 +13,19 @@ public record TalentNodeRank
 
     /// <summary>
     /// Gets the tooltip for the talent node rank.
-    /// This property filled when talent node type is ACTIVE or PASSIVE
     /// </summary>
+    /// <remarks>
+    /// This property filled when talent node type is ACTIVE or PASSIVE.
+    /// </remarks>
     [JsonPropertyName("tooltip")]
     public TalentNodeTooltip Tooltip { get; init; }
 
     /// <summary>
     /// Gets the possible tooltips for the talent node rank.
-    /// This property filled when talent node type is CHOICE
     /// </summary>
+    /// <remarks>
+    /// This property filled when talent node type is CHOICE.
+    /// </remarks>
     [JsonPropertyName("choice_of_tooltips")]
     public TalentNodeTooltip[] ChoiceOfTooltips { get; init; }
 

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/AuctionHouseApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/AuctionHouseApiTests.cs
@@ -12,4 +12,15 @@ public class AuctionHouseApiTests
         await result.Should().BeSuccessfulRequest()
             .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/connected-realm/4/auctions?namespace=dynamic-us&locale=en_US");
     }
+
+    [ResilientFact]
+    public async Task GetCommoditiesAsync_Gets_Commodities()
+    {
+        IAuctionHouseApi warcraftClient = ClientFactory.BuildClient(TimeSpan.FromMinutes(5));
+
+        RequestResult<CommoditiesIndex> result = await warcraftClient.GetCommoditiesAsync("dynamic-us");
+
+        await result.Should().BeSuccessfulRequest()
+            .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/auctions/commodities?namespace=dynamic-us&locale=en_US");
+    }
 }

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PetApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/PetApiTests.cs
@@ -25,6 +25,17 @@ public class PetApiTests
     }
 
     [ResilientFact]
+    public async Task GetPetMediaAsync_Gets_PetMedia()
+    {
+        IPetApi warcraftClient = ClientFactory.BuildClient();
+
+        RequestResult<PetMedia> result = await warcraftClient.GetPetMediaAsync(39, "static-us");
+
+        await result.Should().BeSuccessfulRequest()
+            .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/media/pet/39?namespace=static-us&locale=en_US");
+    }
+
+    [ResilientFact]
     public async Task GetPetAbilitiesIndexAsync_Gets_PetAbilitiesIndex()
     {
         IPetApi warcraftClient = ClientFactory.BuildClient();

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/TalentApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/GameDataApi/TalentApiTests.cs
@@ -3,6 +3,39 @@
 public class TalentApiTests
 {
     [ResilientFact]
+    public async Task GetTalentTreeIndexAsync_Gets_TalentTreeIndex()
+    {
+        ITalentApi warcraftClient = ClientFactory.BuildClient();
+
+        RequestResult<TalentTreeIndex> result = await warcraftClient.GetTalentTreeIndexAsync("static-us");
+
+        await result.Should().BeSuccessfulRequest()
+            .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/talent-tree/index?namespace=static-us&locale=en_US");
+    }
+
+    [ResilientFact]
+    public async Task GetTalentTreeAsync_Gets_TalentTree()
+    {
+        ITalentApi warcraftClient = ClientFactory.BuildClient();
+
+        RequestResult<TalentTree> result = await warcraftClient.GetTalentTreeAsync(786, 262, "static-us");
+
+        await result.Should().BeSuccessfulRequest()
+            .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/talent-tree/786/playable-specialization/262?namespace=static-us&locale=en_US");
+    }
+
+    [ResilientFact]
+    public async Task GetTalentTreeNodesAsync_Gets_TalentTreeNodes()
+    {
+        ITalentApi warcraftClient = ClientFactory.BuildClient();
+
+        RequestResult<TalentTreeNodes> result = await warcraftClient.GetTalentTreeNodesAsync(786, "static-us");
+
+        await result.Should().BeSuccessfulRequest()
+            .BeEquivalentToBlizzardResponseAsync("https://us.api.blizzard.com/data/wow/talent-tree/786?namespace=static-us&locale=en_US");
+    }
+
+    [ResilientFact]
     public async Task GetTalentsIndexAsync_Gets_TalentsIndex()
     {
         ITalentApi warcraftClient = ClientFactory.BuildClient();

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/TestUtilities/ClientFactory.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/TestUtilities/ClientFactory.cs
@@ -1,4 +1,6 @@
-﻿namespace ArgentPonyWarcraftClient.Integration.Tests;
+﻿using System.Net.Http.Headers;
+
+namespace ArgentPonyWarcraftClient.Integration.Tests;
 
 internal static class ClientFactory
 {
@@ -11,6 +13,22 @@ internal static class ClientFactory
             clientSecret: credentials.ClientSecret,
             region: Region.US,
             locale: Locale.en_US);
+    }
+
+    public static IWarcraftClient BuildClient(TimeSpan timeout)
+    {
+        ClientCredentials credentials = ClientCredentialsSource.GetCredentials();
+
+        var client = new HttpClient();
+        client.Timeout = timeout;
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+        return new WarcraftClient(
+            clientId: credentials.ClientId,
+            clientSecret: credentials.ClientSecret,
+            region: Region.US,
+            locale: Locale.en_US,
+            client: client);
     }
 
     public static RawBlizzardClient BuildRawBlizzardClient()

--- a/tests/ArgentPonyWarcraftClient.Integration.Tests/TestUtilities/RawBlizzardClient.cs
+++ b/tests/ArgentPonyWarcraftClient.Integration.Tests/TestUtilities/RawBlizzardClient.cs
@@ -20,6 +20,7 @@ internal class RawBlizzardClient
     static RawBlizzardClient()
     {
         _client = new HttpClient();
+        _client.Timeout = TimeSpan.FromMinutes(5);
     }
 
     public RawBlizzardClient(ClientCredentials credentials)

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/AuctionHouseApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/AuctionHouseApiTests.cs
@@ -12,4 +12,15 @@ public class AuctionHouseApiTests
         RequestResult<AuctionsIndex> result = await warcraftClient.GetAuctionsAsync(4, "dynamic-us");
         Assert.NotNull(result.Value);
     }
+
+    [Fact]
+    public async Task GetCommoditiesAsync_Gets_Commodities()
+    {
+        IAuctionHouseApi warcraftClient = ClientFactory.BuildMockClient(
+            requestUri: "https://us.api.blizzard.com/data/wow/auctions/commodities?namespace=dynamic-us&locale=en_US",
+            responseContent: Resources.CommoditiesResponse);
+
+        RequestResult<CommoditiesIndex> result = await warcraftClient.GetCommoditiesAsync("dynamic-us");
+        Assert.NotNull(result.Value);
+    }
 }

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/PetApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/PetApiTests.cs
@@ -25,6 +25,17 @@ public class PetApiTests
     }
 
     [Fact]
+    public async Task GetPetMediaAsync_Gets_PetMedia()
+    {
+        IPetApi warcraftClient = ClientFactory.BuildMockClient(
+            requestUri: "https://us.api.blizzard.com/data/wow/media/pet/39?namespace=static-us&locale=en_US",
+            responseContent: Resources.PetMediaResponse);
+
+        RequestResult<PetMedia> result = await warcraftClient.GetPetMediaAsync(39, "static-us");
+        Assert.NotNull(result.Value);
+    }
+
+    [Fact]
     public async Task GetPetAbilitiesIndexAsync_Gets_PetAbilitiesIndex()
     {
         IPetApi warcraftClient = ClientFactory.BuildMockClient(

--- a/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/TalentApiTests.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/GameDataApi/TalentApiTests.cs
@@ -3,6 +3,39 @@
 public class TalentApiTests
 {
     [Fact]
+    public async Task GetTalentTreeIndexAsync_Gets_TalentTreeIndex()
+    {
+        ITalentApi warcraftClient = ClientFactory.BuildMockClient(
+            requestUri: "https://us.api.blizzard.com/data/wow/talent-tree/index?namespace=static-us&locale=en_US",
+            responseContent: Resources.TalentTreeIndexResponse);
+
+        RequestResult<TalentTreeIndex> result = await warcraftClient.GetTalentTreeIndexAsync("static-us");
+        Assert.NotNull(result.Value);
+    }
+
+    [Fact]
+    public async Task GetTalentTreeAsync_Gets_TalentTree()
+    {
+        ITalentApi warcraftClient = ClientFactory.BuildMockClient(
+            requestUri: "https://us.api.blizzard.com/data/wow/talent-tree/786/playable-specialization/262?namespace=static-us&locale=en_US",
+            responseContent: Resources.TalentTreeResponse);
+
+        RequestResult<TalentTree> result = await warcraftClient.GetTalentTreeAsync(786, 262, "static-us");
+        Assert.NotNull(result.Value);
+    }
+
+    [Fact]
+    public async Task GetTalentTreeNodesAsync_Gets_TalentTreeNodes()
+    {
+        ITalentApi warcraftClient = ClientFactory.BuildMockClient(
+            requestUri: "https://us.api.blizzard.com/data/wow/talent-tree/786?namespace=static-us&locale=en_US",
+            responseContent: Resources.TalentTreeNodesResponse);
+
+        RequestResult<TalentTreeNodes> result = await warcraftClient.GetTalentTreeNodesAsync(786, "static-us");
+        Assert.NotNull(result.Value);
+    }
+
+    [Fact]
     public async Task GetTalentsIndexAsync_Gets_TalentsIndex()
     {
         ITalentApi warcraftClient = ClientFactory.BuildMockClient(

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
@@ -4035,6 +4035,80 @@ namespace ArgentPonyWarcraftClient.Tests.Properties {
         ///   Looks up a localized string similar to {
         ///  &quot;_links&quot;: {
         ///    &quot;self&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/talent-tree/?namespace=static-10.0.5_47621-us&quot;
+        ///    }
+        ///  },
+        ///  &quot;spec_talent_trees&quot;: [
+        ///    {
+        ///      &quot;key&quot;: {
+        ///        &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/talent-tree/774/playable-specialization/254?namespace=static-10.0.5_47621-us&quot;
+        ///      },
+        ///      &quot;name&quot;: &quot;Marksmanship&quot;
+        ///    },
+        ///    {
+        ///      &quot;key&quot;: {
+        ///        &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/talent-tree/774/playable-specialization/255?namespace=stati [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string TalentTreeIndexResponse {
+            get {
+                return ResourceManager.GetString("TalentTreeIndexResponse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {
+        ///  &quot;_links&quot;: {
+        ///    &quot;self&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/talent-tree/786?namespace=static-10.0.5_47621-us&quot;
+        ///    }
+        ///  },
+        ///  &quot;id&quot;: 786,
+        ///  &quot;spec_talent_trees&quot;: [
+        ///    {
+        ///      &quot;key&quot;: {
+        ///        &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/talent-tree/786/playable-specialization/262?namespace=static-10.0.5_47621-us&quot;
+        ///      },
+        ///      &quot;name&quot;: &quot;Elemental&quot;
+        ///    },
+        ///    {
+        ///      &quot;key&quot;: {
+        ///        &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/talent-tree/786/playable-specialization/264?n [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string TalentTreeNodesResponse {
+            get {
+                return ResourceManager.GetString("TalentTreeNodesResponse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {
+        ///  &quot;_links&quot;: {
+        ///    &quot;self&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/talent-tree/786/playable-specialization/262?namespace=static-10.0.5_47621-us&quot;
+        ///    }
+        ///  },
+        ///  &quot;id&quot;: 786,
+        ///  &quot;playable_class&quot;: {
+        ///    &quot;key&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/playable-class/7?namespace=static-10.0.5_47621-us&quot;
+        ///    },
+        ///    &quot;name&quot;: &quot;Shaman&quot;,
+        ///    &quot;id&quot;: 7
+        ///  },
+        ///  &quot;playable_specialization&quot;: {
+        ///    &quot;key&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/playable-specialization/262?name [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string TalentTreeResponse {
+            get {
+                return ResourceManager.GetString("TalentTreeResponse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {
+        ///  &quot;_links&quot;: {
+        ///    &quot;self&quot;: {
         ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/media/tech-talent/1612?namespace=static-9.0.5_37760-us&quot;
         ///    }
         ///  },

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
@@ -1067,6 +1067,15 @@ namespace ArgentPonyWarcraftClient.Tests.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {&quot;_links&quot;:{&quot;self&quot;:{&quot;href&quot;:&quot;https://us.api.blizzard.com/data/wow/auctions/commodities?namespace=dynamic-us&quot;}},&quot;auctions&quot;:[{&quot;id&quot;:814959956,&quot;item&quot;:{&quot;id&quot;:193255},&quot;quantity&quot;:45,&quot;unit_price&quot;:900000,&quot;time_left&quot;:&quot;SHORT&quot;},{&quot;id&quot;:814959983,&quot;item&quot;:{&quot;id&quot;:117442},&quot;quantity&quot;:7,&quot;unit_price&quot;:8900,&quot;time_left&quot;:&quot;SHORT&quot;},{&quot;id&quot;:814960046,&quot;item&quot;:{&quot;id&quot;:40072},&quot;quantity&quot;:2,&quot;unit_price&quot;:108500,&quot;time_left&quot;:&quot;SHORT&quot;},{&quot;id&quot;:814960100,&quot;item&quot;:{&quot;id&quot;:117453},&quot;quantity&quot;:7,&quot;unit_price&quot;:8700,&quot;time_left&quot;:&quot;SHORT&quot;},{&quot;id&quot;:814960107,&quot;item&quot;:{&quot;id&quot;:19 [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string CommoditiesResponse {
+            get {
+                return ResourceManager.GetString("CommoditiesResponse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {
         ///  &quot;_links&quot;: {
         ///    &quot;self&quot;: {

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
@@ -2621,6 +2621,29 @@ namespace ArgentPonyWarcraftClient.Tests.Properties {
         ///   Looks up a localized string similar to {
         ///  &quot;_links&quot;: {
         ///    &quot;self&quot;: {
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/media/pet/39?namespace=static-10.0.5_47621-us&quot;
+        ///    }
+        ///  },
+        ///  &quot;assets&quot;: [
+        ///    {
+        ///      &quot;key&quot;: &quot;icon&quot;,
+        ///      &quot;value&quot;: &quot;https://render.worldofwarcraft.com/us/icons/56/inv_pet_mechanicalsquirrel.jpg&quot;,
+        ///      &quot;file_data_id&quot;: 656559
+        ///    }
+        ///  ],
+        ///  &quot;id&quot;: 39
+        ///}.
+        /// </summary>
+        internal static string PetMediaResponse {
+            get {
+                return ResourceManager.GetString("PetMediaResponse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {
+        ///  &quot;_links&quot;: {
+        ///    &quot;self&quot;: {
         ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/pet/39?namespace=static-8.3.0_32861-us&quot;
         ///    }
         ///  },

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
@@ -79805,4 +79805,7 @@
   ]
 }</value>
   </data>
+  <data name="CommoditiesResponse" xml:space="preserve">
+    <value>{"_links":{"self":{"href":"https://us.api.blizzard.com/data/wow/auctions/commodities?namespace=dynamic-us"}},"auctions":[{"id":814959956,"item":{"id":193255},"quantity":45,"unit_price":900000,"time_left":"SHORT"},{"id":814959983,"item":{"id":117442},"quantity":7,"unit_price":8900,"time_left":"SHORT"},{"id":814960046,"item":{"id":40072},"quantity":2,"unit_price":108500,"time_left":"SHORT"},{"id":814960100,"item":{"id":117453},"quantity":7,"unit_price":8700,"time_left":"SHORT"},{"id":814960107,"item":{"id":197741},"quantity":13,"unit_price":1100,"time_left":"SHORT"},{"id":814960136,"item":{"id":45196},"quantity":2,"unit_price":9900,"time_left":"VERY_LONG"},{"id":823329585,"item":{"id":194802},"quantity":1,"unit_price":1480000,"time_left":"VERY_LONG"},{"id":823329594,"item":{"id":769},"quantity":1,"unit_price":3400,"time_left":"VERY_LONG"},{"id":823329592,"item":{"id":193050},"quantity":9,"unit_price":500,"time_left":"LONG"}]}</value>
+  </data>
 </root>

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
@@ -79808,4 +79808,21 @@
   <data name="CommoditiesResponse" xml:space="preserve">
     <value>{"_links":{"self":{"href":"https://us.api.blizzard.com/data/wow/auctions/commodities?namespace=dynamic-us"}},"auctions":[{"id":814959956,"item":{"id":193255},"quantity":45,"unit_price":900000,"time_left":"SHORT"},{"id":814959983,"item":{"id":117442},"quantity":7,"unit_price":8900,"time_left":"SHORT"},{"id":814960046,"item":{"id":40072},"quantity":2,"unit_price":108500,"time_left":"SHORT"},{"id":814960100,"item":{"id":117453},"quantity":7,"unit_price":8700,"time_left":"SHORT"},{"id":814960107,"item":{"id":197741},"quantity":13,"unit_price":1100,"time_left":"SHORT"},{"id":814960136,"item":{"id":45196},"quantity":2,"unit_price":9900,"time_left":"VERY_LONG"},{"id":823329585,"item":{"id":194802},"quantity":1,"unit_price":1480000,"time_left":"VERY_LONG"},{"id":823329594,"item":{"id":769},"quantity":1,"unit_price":3400,"time_left":"VERY_LONG"},{"id":823329592,"item":{"id":193050},"quantity":9,"unit_price":500,"time_left":"LONG"}]}</value>
   </data>
+  <data name="PetMediaResponse" xml:space="preserve">
+    <value>{
+  "_links": {
+    "self": {
+      "href": "https://us.api.blizzard.com/data/wow/media/pet/39?namespace=static-10.0.5_47621-us"
+    }
+  },
+  "assets": [
+    {
+      "key": "icon",
+      "value": "https://render.worldofwarcraft.com/us/icons/56/inv_pet_mechanicalsquirrel.jpg",
+      "file_data_id": 656559
+    }
+  ],
+  "id": 39
+}</value>
+  </data>
 </root>

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
@@ -79825,4 +79825,917 @@
   "id": 39
 }</value>
   </data>
+  <data name="TalentTreeIndexResponse" xml:space="preserve">
+    <value>{
+  "_links": {
+    "self": {
+      "href": "https://us.api.blizzard.com/data/wow/talent-tree/?namespace=static-10.0.5_47621-us"
+    }
+  },
+  "spec_talent_trees": [
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/774/playable-specialization/254?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Marksmanship"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/774/playable-specialization/255?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Survival"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/774/playable-specialization/253?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Beast Mastery"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/786/playable-specialization/262?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Elemental"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/786/playable-specialization/264?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Restoration"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/786/playable-specialization/263?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Enhancement"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/793/playable-specialization/102?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Balance"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/793/playable-specialization/103?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Feral"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/850/playable-specialization/72?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Fury"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/781/playable-specialization/269?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Windwalker"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/781/playable-specialization/268?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Brewmaster"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/781/playable-specialization/270?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Mistweaver"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/701/playable-specialization/1468?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Preservation"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/701/playable-specialization/1467?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Devastation"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/750/playable-specialization/250?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Blood"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/750/playable-specialization/252?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Unholy"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/750/playable-specialization/251?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Frost"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/790/playable-specialization/66?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Protection"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/790/playable-specialization/65?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Holy"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/790/playable-specialization/70?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Retribution"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/790/playable-specialization/70?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Retribution"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/795/playable-specialization/257?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Holy"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/795/playable-specialization/256?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Discipline"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/795/playable-specialization/258?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Shadow"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/658/playable-specialization/64?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Frost"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/658/playable-specialization/63?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Fire"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/658/playable-specialization/62?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Arcane"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/852/playable-specialization/260?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Outlaw"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/852/playable-specialization/259?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Assassination"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/852/playable-specialization/261?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Subtlety"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/854/playable-specialization/581?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Vengeance"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/854/playable-specialization/577?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Havoc"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/720/playable-specialization/265?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Affliction"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/720/playable-specialization/266?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Demonology"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/720/playable-specialization/267?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Destruction"
+    }
+  ],
+  "class_talent_trees": [
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/774?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Hunter"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/786?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Shaman"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/793?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Druid"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/850?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Warrior"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/781?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Monk"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/701?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Evoker"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/750?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Death Knight"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/790?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Paladin"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/795?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Priest"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/658?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Mage"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/852?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Rogue"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/854?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Demon Hunter"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/720?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Warlock"
+    }
+  ]
+}</value>
+  </data>
+  <data name="TalentTreeNodesResponse" xml:space="preserve">
+    <value>{
+  "_links": {
+    "self": {
+      "href": "https://us.api.blizzard.com/data/wow/talent-tree/786?namespace=static-10.0.5_47621-us"
+    }
+  },
+  "id": 786,
+  "spec_talent_trees": [
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/786/playable-specialization/262?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Elemental"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/786/playable-specialization/264?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Restoration"
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/talent-tree/786/playable-specialization/263?namespace=static-10.0.5_47621-us"
+      },
+      "name": "Enhancement"
+    }
+  ],
+  "talent_nodes": [
+    {
+      "id": 80937,
+      "node_type": {
+        "id": 2,
+        "type": "CHOICE"
+      },
+      "ranks": [
+        {
+          "rank": 1,
+          "choice_of_tooltips": [
+            {
+              "talent": {
+                "key": {
+                  "href": "https://us.api.blizzard.com/data/wow/talent/106873?namespace=static-10.0.5_47621-us"
+                },
+                "name": "Refreshing Waters",
+                "id": 106873
+              },
+              "spell_tooltip": {
+                "spell": {
+                  "key": {
+                    "href": "https://us.api.blizzard.com/data/wow/spell/393905?namespace=static-10.0.5_47621-us"
+                  },
+                  "name": "Refreshing Waters",
+                  "id": 393905
+                },
+                "description": "Your Healing Surge is 25% more effective on yourself.\r\n",
+                "cast_time": "Passive"
+              }
+            },
+            {
+              "talent": {
+                "key": {
+                  "href": "https://us.api.blizzard.com/data/wow/talent/106872?namespace=static-10.0.5_47621-us"
+                },
+                "name": "Ancestral Wolf Affinity",
+                "id": 106872
+              },
+              "spell_tooltip": {
+                "spell": {
+                  "key": {
+                    "href": "https://us.api.blizzard.com/data/wow/spell/382197?namespace=static-10.0.5_47621-us"
+                  },
+                  "name": "Ancestral Wolf Affinity",
+                  "id": 382197
+                },
+                "description": "Cleanse Spirit, Wind Shear, Purge, and totem casts no longer cancel Ghost Wolf.",
+                "cast_time": "Passive"
+              }
+            }
+          ]
+        }
+      ],
+      "display_row": 6,
+      "display_col": 17,
+      "raw_position_x": 11400,
+      "raw_position_y": 4200
+    },
+    {
+      "id": 80938,
+      "node_type": {
+        "id": 1,
+        "type": "PASSIVE"
+      },
+      "ranks": [
+        {
+          "rank": 1,
+          "tooltip": {
+            "talent": {
+              "key": {
+                "href": "https://us.api.blizzard.com/data/wow/talent/106880?namespace=static-10.0.5_47621-us"
+              },
+              "name": "Overflowing Maelstrom",
+              "id": 106880
+            },
+            "spell_tooltip": {
+              "spell": {
+                "key": {
+                  "href": "https://us.api.blizzard.com/data/wow/spell/384149?namespace=static-10.0.5_47621-us"
+                },
+                "name": "Overflowing Maelstrom",
+                "id": 384149
+              },
+              "description": "Your damage or healing spells will now consume up to 10 Maelstrom Weapon stacks. ",
+              "cast_time": "Passive"
+            }
+          }
+        }
+      ],
+      "display_row": 5,
+      "display_col": 18,
+      "raw_position_x": 12000,
+      "raw_position_y": 3600
+    },
+    {
+      "id": 80939,
+      "node_type": {
+        "id": 1,
+        "type": "PASSIVE"
+      },
+      "ranks": [
+        {
+          "rank": 1,
+          "tooltip": {
+            "talent": {
+              "key": {
+                "href": "https://us.api.blizzard.com/data/wow/talent/106871?namespace=static-10.0.5_47621-us"
+              },
+              "name": "Raging Maelstrom",
+              "id": 106871
+            },
+            "spell_tooltip": {
+              "spell": {
+                "key": {
+                  "href": "https://us.api.blizzard.com/data/wow/spell/384143?namespace=static-10.0.5_47621-us"
+                },
+                "name": "Raging Maelstrom",
+                "id": 384143
+              },
+              "description": "Maelstrom Weapon can now stack 5 additional times, and Maelstrom Weapon now increases the damage or healing of spells it affects by an additional 5% per stack.",
+              "cast_time": "Passive"
+            }
+          }
+        }
+      ],
+      "display_row": 4,
+      "display_col": 18,
+      "raw_position_x": 12000,
+      "raw_position_y": 3000
+    },
+    {
+      "id": 92219,
+      "node_type": {
+        "id": 2,
+        "type": "CHOICE"
+      },
+      "ranks": [
+        {
+          "rank": 1,
+          "choice_of_tooltips": [
+            {
+              "talent": {
+                "key": {
+                  "href": "https://us.api.blizzard.com/data/wow/talent/106894?namespace=static-10.0.5_47621-us"
+                },
+                "name": "Deeply Rooted Elements",
+                "id": 106894
+              },
+              "spell_tooltip": {
+                "spell": {
+                  "key": {
+                    "href": "https://us.api.blizzard.com/data/wow/spell/378270?namespace=static-10.0.5_47621-us"
+                  },
+                  "name": "Deeply Rooted Elements",
+                  "id": 378270
+                },
+                "description": "Casting Stormstrike has a 7% chance to activate Ascendance for 6.0 sec.\r\n\r\n Ascendance\r\n\r\nTransform into an Air Ascendant for 15 sec, immediately dealing 979 Nature damage to any enemy within 8 yds, reducing the cooldown and cost of Stormstrike by 60%, and transforming your auto attack and Stormstrike into Wind attacks which bypass armor and have a 30 yd range.",
+                "cast_time": "Passive"
+              }
+            },
+            {
+              "talent": {
+                "key": {
+                  "href": "https://us.api.blizzard.com/data/wow/talent/119296?namespace=static-10.0.5_47621-us"
+                },
+                "name": "Ascendance",
+                "id": 119296
+              },
+              "spell_tooltip": {
+                "spell": {
+                  "key": {
+                    "href": "https://us.api.blizzard.com/data/wow/spell/114051?namespace=static-10.0.5_47621-us"
+                  },
+                  "name": "Ascendance",
+                  "id": 114051
+                },
+                "description": "Transform into an Air Ascendant for 15 sec, immediately dealing 990 Nature damage to any enemy within 8 yds, reducing the cooldown and cost of Stormstrike by 60%, and transforming your auto attack and Stormstrike into Wind attacks which bypass armor and have a 30 yd range.",
+                "cast_time": "Instant",
+                "cooldown": "3 min cooldown"
+              }
+            }
+          ]
+        }
+      ],
+      "display_row": 8,
+      "display_col": 20,
+      "raw_position_x": 13200,
+      "raw_position_y": 5400
+    }
+  ]
+}</value>
+  </data>
+  <data name="TalentTreeResponse" xml:space="preserve">
+    <value>{
+  "_links": {
+    "self": {
+      "href": "https://us.api.blizzard.com/data/wow/talent-tree/786/playable-specialization/262?namespace=static-10.0.5_47621-us"
+    }
+  },
+  "id": 786,
+  "playable_class": {
+    "key": {
+      "href": "https://us.api.blizzard.com/data/wow/playable-class/7?namespace=static-10.0.5_47621-us"
+    },
+    "name": "Shaman",
+    "id": 7
+  },
+  "playable_specialization": {
+    "key": {
+      "href": "https://us.api.blizzard.com/data/wow/playable-specialization/262?namespace=static-10.0.5_47621-us"
+    },
+    "name": "Elemental",
+    "id": 262
+  },
+  "name": "Elemental",
+  "media": {
+    "key": {
+      "href": "https://us.api.blizzard.com/data/wow/media/talent-tree/786/playable-specialization/262?namespace=static-10.0.5_47621-us"
+    }
+  },
+  "restriction_lines": [
+    {
+      "required_points": 20,
+      "restricted_row": 7.5,
+      "is_for_class": true
+    },
+    {
+      "required_points": 8,
+      "restricted_row": 4.5,
+      "is_for_class": true
+    },
+    {
+      "required_points": 8,
+      "restricted_row": 4.5,
+      "is_for_class": false
+    },
+    {
+      "required_points": 20,
+      "restricted_row": 7.5,
+      "is_for_class": false
+    }
+  ],
+  "class_talent_nodes": [
+    {
+      "id": 81063,
+      "unlocks": [
+        81106,
+        81064
+      ],
+      "node_type": {
+        "id": 0,
+        "type": "ACTIVE"
+      },
+      "ranks": [
+        {
+          "rank": 1,
+          "tooltip": {
+            "talent": {
+              "key": {
+                "href": "https://us.api.blizzard.com/data/wow/talent/106951?namespace=static-10.0.5_47621-us"
+              },
+              "name": "Chain Heal",
+              "id": 106951
+            },
+            "spell_tooltip": {
+              "spell": {
+                "key": {
+                  "href": "https://us.api.blizzard.com/data/wow/spell/1064?namespace=static-10.0.5_47621-us"
+                },
+                "name": "Chain Heal",
+                "id": 1064
+              },
+              "description": "Heals the friendly target for 13,022, then jumps to heal the 3 most injured nearby allies. Healing is reduced by 30% with each jump.",
+              "cast_time": "2.5 sec cast",
+              "power_cost": "75,000 Mana",
+              "range": "40 yd range"
+            }
+          }
+        }
+      ],
+      "display_row": 1,
+      "display_col": 1,
+      "raw_position_x": 1800,
+      "raw_position_y": 1200
+    },
+    {
+      "id": 81062,
+      "unlocks": [
+        81064,
+        81068,
+        81067
+      ],
+      "node_type": {
+        "id": 0,
+        "type": "ACTIVE"
+      },
+      "ranks": [
+        {
+          "rank": 1,
+          "tooltip": {
+            "talent": {
+              "key": {
+                "href": "https://us.api.blizzard.com/data/wow/talent/106952?namespace=static-10.0.5_47621-us"
+              },
+              "name": "Lava Burst",
+              "id": 106952
+            },
+            "spell_tooltip": {
+              "spell": {
+                "key": {
+                  "href": "https://us.api.blizzard.com/data/wow/spell/51505?namespace=static-10.0.5_47621-us"
+                },
+                "name": "Lava Burst",
+                "id": 51505
+              },
+              "description": "Hurls molten lava at the target, dealing 5,354 Fire damage. Lava Burst will always critically strike if the target is affected by Flame Shock.",
+              "cast_time": "2 sec cast",
+              "power_cost": "6,250 Mana",
+              "range": "40 yd range"
+            }
+          },
+          "default_points": 1
+        }
+      ],
+      "display_row": 1,
+      "display_col": 3,
+      "raw_position_x": 3000,
+      "raw_position_y": 1200
+    },
+    {
+      "id": 81090,
+      "locked_by": [
+        81091
+      ],
+      "node_type": {
+        "id": 2,
+        "type": "CHOICE"
+      },
+      "ranks": [
+        {
+          "rank": 1,
+          "choice_of_tooltips": [
+            {
+              "talent": {
+                "key": {
+                  "href": "https://us.api.blizzard.com/data/wow/talent/106999?namespace=static-10.0.5_47621-us"
+                },
+                "name": "Call of the Elements",
+                "id": 106999
+              },
+              "spell_tooltip": {
+                "spell": {
+                  "key": {
+                    "href": "https://us.api.blizzard.com/data/wow/spell/383011?namespace=static-10.0.5_47621-us"
+                  },
+                  "name": "Call of the Elements",
+                  "id": 383011
+                },
+                "description": "Reduces the cooldown of Totemic Recall by 60 sec.",
+                "cast_time": "Passive"
+              }
+            },
+            {
+              "talent": {
+                "key": {
+                  "href": "https://us.api.blizzard.com/data/wow/talent/106998?namespace=static-10.0.5_47621-us"
+                },
+                "name": "Creation Core",
+                "id": 106998
+              },
+              "spell_tooltip": {
+                "spell": {
+                  "key": {
+                    "href": "https://us.api.blizzard.com/data/wow/spell/383012?namespace=static-10.0.5_47621-us"
+                  },
+                  "name": "Creation Core",
+                  "id": 383012
+                },
+                "description": "Totemic Recall affects an additional totem.",
+                "cast_time": "Passive"
+              }
+            }
+          ]
+        }
+      ],
+      "display_row": 10,
+      "display_col": 8,
+      "raw_position_x": 6000,
+      "raw_position_y": 6600
+    }
+  ],
+  "spec_talent_nodes": [
+    {
+      "id": 80984,
+      "unlocks": [
+        80981,
+        80983,
+        80985
+      ],
+      "node_type": {
+        "id": 0,
+        "type": "ACTIVE"
+      },
+      "ranks": [
+        {
+          "rank": 1,
+          "tooltip": {
+            "talent": {
+              "key": {
+                "href": "https://us.api.blizzard.com/data/wow/talent/106811?namespace=static-10.0.5_47621-us"
+              },
+              "name": "Earth Shock",
+              "id": 106811
+            },
+            "spell_tooltip": {
+              "spell": {
+                "key": {
+                  "href": "https://us.api.blizzard.com/data/wow/spell/8042?namespace=static-10.0.5_47621-us"
+                },
+                "name": "Earth Shock",
+                "id": 8042
+              },
+              "description": "Instantly shocks the target with concussive force, causing 14,751 Nature damage.",
+              "cast_time": "Instant",
+              "power_cost": "60 Maelstrom",
+              "range": "40 yd range"
+            }
+          }
+        }
+      ],
+      "display_row": 1,
+      "display_col": 18,
+      "raw_position_x": 12000,
+      "raw_position_y": 1200
+    },
+    {
+      "id": 80985,
+      "locked_by": [
+        80984
+      ],
+      "unlocks": [
+        80986
+      ],
+      "node_type": {
+        "id": 0,
+        "type": "ACTIVE"
+      },
+      "ranks": [
+        {
+          "rank": 1,
+          "tooltip": {
+            "talent": {
+              "key": {
+                "href": "https://us.api.blizzard.com/data/wow/talent/106814?namespace=static-10.0.5_47621-us"
+              },
+              "name": "Earthquake",
+              "id": 106814
+            },
+            "spell_tooltip": {
+              "spell": {
+                "key": {
+                  "href": "https://us.api.blizzard.com/data/wow/spell/61882?namespace=static-10.0.5_47621-us"
+                },
+                "name": "Earthquake",
+                "id": 61882
+              },
+              "description": "Causes the earth within 8 yards of the target location to tremble and break, dealing 7,395 Physical damage over 6 sec and has a 5% chance to knock the enemy down.",
+              "cast_time": "Instant",
+              "power_cost": "60 Maelstrom",
+              "range": "40 yd range"
+            }
+          }
+        }
+      ],
+      "display_row": 2,
+      "display_col": 17,
+      "raw_position_x": 11400,
+      "raw_position_y": 1800
+    },
+    {
+      "id": 81001,
+      "locked_by": [
+        81002
+      ],
+      "node_type": {
+        "id": 1,
+        "type": "PASSIVE"
+      },
+      "ranks": [
+        {
+          "rank": 1,
+          "tooltip": {
+            "talent": {
+              "key": {
+                "href": "https://us.api.blizzard.com/data/wow/talent/106825?namespace=static-10.0.5_47621-us"
+              },
+              "name": "Further Beyond",
+              "id": 106825
+            },
+            "spell_tooltip": {
+              "spell": {
+                "key": {
+                  "href": "https://us.api.blizzard.com/data/wow/spell/381787?namespace=static-10.0.5_47621-us"
+                },
+                "name": "Further Beyond",
+                "id": 381787
+              },
+              "description": "Casting Earth Shock or Earthquake while Ascendance is active extends the duration of Ascendance by 2.5 sec.\r\n\r\nCasting Elemental Blast while Ascendance is active extends the duration of Ascendance by 3.5 sec.",
+              "cast_time": "Passive"
+            }
+          }
+        }
+      ],
+      "display_row": 10,
+      "display_col": 19,
+      "raw_position_x": 12600,
+      "raw_position_y": 6600
+    },
+    {
+      "id": 81006,
+      "locked_by": [
+        81007,
+        81005
+      ],
+      "node_type": {
+        "id": 2,
+        "type": "CHOICE"
+      },
+      "ranks": [
+        {
+          "rank": 1,
+          "choice_of_tooltips": [
+            {
+              "talent": {
+                "key": {
+                  "href": "https://us.api.blizzard.com/data/wow/talent/106849?namespace=static-10.0.5_47621-us"
+                },
+                "name": "Windspeaker's Lava Resurgence",
+                "id": 106849
+              },
+              "spell_tooltip": {
+                "spell": {
+                  "key": {
+                    "href": "https://us.api.blizzard.com/data/wow/spell/378268?namespace=static-10.0.5_47621-us"
+                  },
+                  "name": "Windspeaker's Lava Resurgence",
+                  "id": 378268
+                },
+                "description": "When you cast Earth Shock, Elemental Blast, or Earthquake, gain Lava Surge and increase the damage of your next Lava Burst by 10%.",
+                "cast_time": "Passive"
+              }
+            },
+            {
+              "talent": {
+                "key": {
+                  "href": "https://us.api.blizzard.com/data/wow/talent/106848?namespace=static-10.0.5_47621-us"
+                },
+                "name": "Skybreaker's Fiery Demise",
+                "id": 106848
+              },
+              "spell_tooltip": {
+                "spell": {
+                  "key": {
+                    "href": "https://us.api.blizzard.com/data/wow/spell/378310?namespace=static-10.0.5_47621-us"
+                  },
+                  "name": "Skybreaker's Fiery Demise",
+                  "id": 378310
+                },
+                "description": "Flame Shock damage over time critical strikes reduce the cooldown of your Fire and Storm Elemental by 1.0 sec, and Flame Shock has a 50% increased critical strike chance.",
+                "cast_time": "Passive"
+              }
+            }
+          ]
+        }
+      ],
+      "display_row": 10,
+      "display_col": 21,
+      "raw_position_x": 13800,
+      "raw_position_y": 6600
+    }
+  ]
+}</value>
+  </data>
 </root>


### PR DESCRIPTION
- Added support for Commodities on the Auction House API.  The document returned by this call is very large, so it requires special timeout handling.
- Added support for Pet Media on the Pet API.
- Added tests for the Talent Tree Index, Talent Tree, and Talent Tree Nodes on the Talent API.
- Minor tweaks to the /// documentation on the `ITalentApi` interface and the `TalentNodeRank` class.