### PR TITLE
Fixes to get tests working again

### DIFF
--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/PlayableClass/PlayableClass.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/PlayableClass/PlayableClass.cs
@@ -52,4 +52,10 @@ public record PlayableClass
     /// </summary>
     [JsonPropertyName("pvp_talent_slots")]
     public Self PvpTalentSlots { get; init; }
+
+    /// <summary>
+    /// Gets references to the playable races that are compatible with this playable class.
+    /// </summary>
+    [JsonPropertyName("playable_races")]
+    public PlayableRaceReference[] PlayableRaces { get; init; }
 }

--- a/src/ArgentPonyWarcraftClient/Models/GameDataApi/PlayableRace/PlayableRace.cs
+++ b/src/ArgentPonyWarcraftClient/Models/GameDataApi/PlayableRace/PlayableRace.cs
@@ -46,4 +46,10 @@ public record PlayableRace
     /// </summary>
     [JsonPropertyName("is_allied_race")]
     public bool IsAlliedRace { get; init; }
+
+    /// <summary>
+    /// Gets references to the playable classes that are compatible with this playable race.
+    /// </summary>
+    [JsonPropertyName("playable_classes")]
+    public PlayableClassReference[] PlayableClasses { get; init; }
 }

--- a/tests/ArgentPonyWarcraftClient.Tests/ClientFactory.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/ClientFactory.cs
@@ -10,7 +10,7 @@ internal static class ClientFactory
         var mockHttp = new MockHttpMessageHandler();
 
         mockHttp
-            .When("https://us.battle.net/oauth/token")
+            .When("https://oauth.battle.net/oauth/token")
             .Respond(
                 mediaType: "application/json",
                 content: @"{""access_token"": ""ACCESS-TOKEN"", ""token_type"": ""bearer"", ""expires_in"": 86399, ""scope"": ""example.scope""}");
@@ -32,7 +32,7 @@ internal static class ClientFactory
         var mockHttp = new MockHttpMessageHandler();
 
         mockHttp
-            .When("https://us.battle.net/oauth/token")
+            .When("https://oauth.battle.net/oauth/token")
             .Respond(
                 mediaType: "application/json",
                 content: @"{""access_token"": ""ACCESS-TOKEN"", ""token_type"": ""bearer"", ""expires_in"": 86399, ""scope"": ""example.scope""}");

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.Designer.cs
@@ -2747,7 +2747,7 @@ namespace ArgentPonyWarcraftClient.Tests.Properties {
         ///   Looks up a localized string similar to {
         ///  &quot;_links&quot;: {
         ///    &quot;self&quot;: {
-        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/playable-class/7?namespace=static-8.3.0_32861-us&quot;
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/playable-class/7?namespace=static-10.0.7_48520-us&quot;
         ///    }
         ///  },
         ///  &quot;id&quot;: 7,
@@ -2758,7 +2758,7 @@ namespace ArgentPonyWarcraftClient.Tests.Properties {
         ///  },
         ///  &quot;power_type&quot;: {
         ///    &quot;key&quot;: {
-        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/power-type/0?namespace=static-8.3.0_32861-us&quot;
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/power-type/0?namespace=static-10.0.7_48520-us&quot;
         ///    },
         ///    &quot;name&quot;: &quot;Mana&quot;,
         ///    &quot;id&quot;: 0
@@ -2766,7 +2766,7 @@ namespace ArgentPonyWarcraftClient.Tests.Properties {
         ///  &quot;specializations&quot;: [
         ///    {
         ///      &quot;key&quot;: {
-        ///        &quot;href&quot;: &quot;https://us.ap [rest of string was truncated]&quot;;.
+        ///        &quot;href&quot;: &quot;https://us. [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string PlayableClassResponse {
             get {
@@ -2778,7 +2778,7 @@ namespace ArgentPonyWarcraftClient.Tests.Properties {
         ///   Looks up a localized string similar to {
         ///  &quot;_links&quot;: {
         ///    &quot;self&quot;: {
-        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/playable-race/2?namespace=static-8.3.0_32861-us&quot;
+        ///      &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/playable-race/2?namespace=static-10.0.7_48520-us&quot;
         ///    }
         ///  },
         ///  &quot;id&quot;: 2,
@@ -2792,8 +2792,11 @@ namespace ArgentPonyWarcraftClient.Tests.Properties {
         ///    &quot;name&quot;: &quot;Horde&quot;
         ///  },
         ///  &quot;is_selectable&quot;: true,
-        ///  &quot;is_allied_race&quot;: false
-        ///}.
+        ///  &quot;is_allied_race&quot;: false,
+        ///  &quot;playable_classes&quot;: [
+        ///    {
+        ///      &quot;key&quot;: {
+        ///        &quot;href&quot;: &quot;https://us.api.blizzard.com/data/wow/playable-class/6?namespace=static-10.0.7_4852 [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string PlayableRaceResponse {
             get {

--- a/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
+++ b/tests/ArgentPonyWarcraftClient.Tests/Properties/Resources.resx
@@ -55403,7 +55403,7 @@
     <value>{
   "_links": {
     "self": {
-      "href": "https://us.api.blizzard.com/data/wow/playable-class/7?namespace=static-8.3.0_32861-us"
+      "href": "https://us.api.blizzard.com/data/wow/playable-class/7?namespace=static-10.0.7_48520-us"
     }
   },
   "id": 7,
@@ -55414,7 +55414,7 @@
   },
   "power_type": {
     "key": {
-      "href": "https://us.api.blizzard.com/data/wow/power-type/0?namespace=static-8.3.0_32861-us"
+      "href": "https://us.api.blizzard.com/data/wow/power-type/0?namespace=static-10.0.7_48520-us"
     },
     "name": "Mana",
     "id": 0
@@ -55422,21 +55422,21 @@
   "specializations": [
     {
       "key": {
-        "href": "https://us.api.blizzard.com/data/wow/playable-specialization/262?namespace=static-8.3.0_32861-us"
+        "href": "https://us.api.blizzard.com/data/wow/playable-specialization/262?namespace=static-10.0.7_48520-us"
       },
       "name": "Elemental",
       "id": 262
     },
     {
       "key": {
-        "href": "https://us.api.blizzard.com/data/wow/playable-specialization/263?namespace=static-8.3.0_32861-us"
+        "href": "https://us.api.blizzard.com/data/wow/playable-specialization/263?namespace=static-10.0.7_48520-us"
       },
       "name": "Enhancement",
       "id": 263
     },
     {
       "key": {
-        "href": "https://us.api.blizzard.com/data/wow/playable-specialization/264?namespace=static-8.3.0_32861-us"
+        "href": "https://us.api.blizzard.com/data/wow/playable-specialization/264?namespace=static-10.0.7_48520-us"
       },
       "name": "Restoration",
       "id": 264
@@ -55444,13 +55444,120 @@
   ],
   "media": {
     "key": {
-      "href": "https://us.api.blizzard.com/data/wow/media/playable-class/7?namespace=static-8.3.0_32861-us"
+      "href": "https://us.api.blizzard.com/data/wow/media/playable-class/7?namespace=static-10.0.7_48520-us"
     },
     "id": 7
   },
   "pvp_talent_slots": {
-    "href": "https://us.api.blizzard.com/data/wow/playable-class/7/pvp-talent-slots?namespace=static-8.3.0_32861-us"
-  }
+    "href": "https://us.api.blizzard.com/data/wow/playable-class/7/pvp-talent-slots?namespace=static-10.0.7_48520-us"
+  },
+  "playable_races": [
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/playable-race/28?namespace=static-10.0.7_48520-us"
+      },
+      "name": "Highmountain Tauren",
+      "id": 28
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/playable-race/6?namespace=static-10.0.7_48520-us"
+      },
+      "name": "Tauren",
+      "id": 6
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/playable-race/11?namespace=static-10.0.7_48520-us"
+      },
+      "name": "Draenei",
+      "id": 11
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/playable-race/9?namespace=static-10.0.7_48520-us"
+      },
+      "name": "Goblin",
+      "id": 9
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/playable-race/24?namespace=static-10.0.7_48520-us"
+      },
+      "name": "Pandaren",
+      "id": 24
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/playable-race/8?namespace=static-10.0.7_48520-us"
+      },
+      "name": "Troll",
+      "id": 8
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/playable-race/2?namespace=static-10.0.7_48520-us"
+      },
+      "name": "Orc",
+      "id": 2
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/playable-race/31?namespace=static-10.0.7_48520-us"
+      },
+      "name": "Zandalari Troll",
+      "id": 31
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/playable-race/35?namespace=static-10.0.7_48520-us"
+      },
+      "name": "Vulpera",
+      "id": 35
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/playable-race/34?namespace=static-10.0.7_48520-us"
+      },
+      "name": "Dark Iron Dwarf",
+      "id": 34
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/playable-race/36?namespace=static-10.0.7_48520-us"
+      },
+      "name": "Mag'har Orc",
+      "id": 36
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/playable-race/25?namespace=static-10.0.7_48520-us"
+      },
+      "name": "Pandaren",
+      "id": 25
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/playable-race/32?namespace=static-10.0.7_48520-us"
+      },
+      "name": "Kul Tiran",
+      "id": 32
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/playable-race/3?namespace=static-10.0.7_48520-us"
+      },
+      "name": "Dwarf",
+      "id": 3
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/playable-race/26?namespace=static-10.0.7_48520-us"
+      },
+      "name": "Pandaren",
+      "id": 26
+    }
+  ]
 }</value>
   </data>
   <data name="PlayableClassMediaResponse" xml:space="preserve">
@@ -55500,7 +55607,7 @@
     <value>{
   "_links": {
     "self": {
-      "href": "https://us.api.blizzard.com/data/wow/playable-race/2?namespace=static-8.3.0_32861-us"
+      "href": "https://us.api.blizzard.com/data/wow/playable-race/2?namespace=static-10.0.7_48520-us"
     }
   },
   "id": 2,
@@ -55514,7 +55621,72 @@
     "name": "Horde"
   },
   "is_selectable": true,
-  "is_allied_race": false
+  "is_allied_race": false,
+  "playable_classes": [
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/playable-class/6?namespace=static-10.0.7_48520-us"
+      },
+      "name": "Death Knight",
+      "id": 6
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/playable-class/5?namespace=static-10.0.7_48520-us"
+      },
+      "name": "Priest",
+      "id": 5
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/playable-class/9?namespace=static-10.0.7_48520-us"
+      },
+      "name": "Warlock",
+      "id": 9
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/playable-class/4?namespace=static-10.0.7_48520-us"
+      },
+      "name": "Rogue",
+      "id": 4
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/playable-class/8?namespace=static-10.0.7_48520-us"
+      },
+      "name": "Mage",
+      "id": 8
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/playable-class/1?namespace=static-10.0.7_48520-us"
+      },
+      "name": "Warrior",
+      "id": 1
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/playable-class/10?namespace=static-10.0.7_48520-us"
+      },
+      "name": "Monk",
+      "id": 10
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/playable-class/7?namespace=static-10.0.7_48520-us"
+      },
+      "name": "Shaman",
+      "id": 7
+    },
+    {
+      "key": {
+        "href": "https://us.api.blizzard.com/data/wow/playable-class/3?namespace=static-10.0.7_48520-us"
+      },
+      "name": "Hunter",
+      "id": 3
+    }
+  ]
 }</value>
   </data>
   <data name="PlayableRacesIndexResponse" xml:space="preserve">


### PR DESCRIPTION
Added some fixes to get the unit and integration tests working again.  Updated the `ClientFactory` for the unit tests to expect https://oauth.battle.net/oauth/token instead of https://us.battle.net/oauth/token to adapt to the changes in https://github.com/blizzard-net/warcraft/pull/212.  Also updated the `PlayableClass` and `PlayableRace` model classes to add new properties that indicate which classes and races can be combined.