### PR TITLE
Fixed issues with NuGet packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,12 +34,12 @@ jobs:
       with:
         name: NuGet packages
         path: |
-          artifacts/*.nupkg
-          artifacts/*.snupkg
+          artifacts/package/release/*.nupkg
+          artifacts/package/release/*.snupkg
 
     - name: Push NuGet packages to NuGet
       if: ${{ startsWith(github.ref, 'refs/tags/v') }} # Only for a tag
-      run: dotnet nuget push "artifacts/**.nupkg" --skip-duplicate --api-key ${{ secrets.NUGET_KEY }} --source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push "artifacts/package/release/**.nupkg" --skip-duplicate --api-key ${{ secrets.NUGET_KEY }} --source https://api.nuget.org/v3/index.json
 
     - name: Create GitHub Release
       if: ${{ startsWith(github.ref, 'refs/tags/v') }} # Only for a tag

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,8 @@
     <Authors>Dan Jagnow, William Wolfram, and Travis Boatman</Authors>
     <Copyright>Copyright © 2017-2024 The ArgentPonyWarcraftClient Contributors</Copyright>
     <ArtifactsPath>$(MSBuildThisFileDirectory)artifacts</ArtifactsPath>
-    <DefaultArtifactsFileMatch>*.nupkg *.snupkg</DefaultArtifactsFileMatch>
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+    <ArtifactsPath>$(MSBuildThisFileDirectory)artifacts</ArtifactsPath>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,7 +25,6 @@
   </ItemGroup>
 
   <ItemGroup Label="Global package references">
-    <GlobalPackageReference Include="Microsoft.Build.Artifacts" Version="6.1.10" />
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" />
   </ItemGroup>

--- a/src/ArgentPonyWarcraftClient.Extensions.DependencyInjection/ArgentPonyWarcraftClient.Extensions.DependencyInjection.csproj
+++ b/src/ArgentPonyWarcraftClient.Extensions.DependencyInjection/ArgentPonyWarcraftClient.Extensions.DependencyInjection.csproj
@@ -5,6 +5,7 @@
     <Description>Extensions of Microsoft.Extensions.DependencyInjection for the Argent Pony .NET client.</Description>
     <Title>Argent Pony Warcraft Client Dependency Injection</Title>
     <PackageTags>Warcraft;World-of-Warcraft;WoW;Blizzard;Dependency-Injection;DI</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>ArgentPony.png</PackageIcon>
     <LangVersion>10</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/ArgentPonyWarcraftClient/ArgentPonyWarcraftClient.csproj
+++ b/src/ArgentPonyWarcraftClient/ArgentPonyWarcraftClient.csproj
@@ -6,6 +6,7 @@
     <Description>The Argent Pony .NET client for the Blizzard World of Warcraft Game Data and Profile APIs</Description>
     <Title>Argent Pony Warcraft Client</Title>
     <PackageTags>Warcraft;World-of-Warcraft;WoW;Blizzard</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>ArgentPony.png</PackageIcon>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>


### PR DESCRIPTION
Fixed issues with NuGet packages.  Updated the **Directory.Build.props** and **Directory.Packages.props** to rely on the .NET 8 artifacts output layout (see https://learn.microsoft.com/en-us/dotnet/core/sdk/artifacts-output) instead of the **Microsoft.Build.Artifacts** SDK.  Updated the GitHub Actions **build.yml** to locate the NuGet packages in their new output path.  Added a `PackageReadmeFile` MSBuild property to the project files to reference the **README.md** that was already included.